### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,4 +1,6 @@
 name: Docker Image
+permissions:
+  contents: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/pnoker/iot-dc3/security/code-scanning/1](https://github.com/pnoker/iot-dc3/security/code-scanning/1)

The best way to fix the issue is to add an explicit `permissions:` block to the workflow, granting only the permissions needed.  
- Because the workflow creates a release (`softprops/action-gh-release@v2`) at the end, it needs `contents: write` permission.  
- For all other actions (checkout, maven build, docker operations), only read permissions on the repo contents are needed.
- The most maintainable and clear approach is to set `permissions:` at the workflow root level (so it applies to all jobs), like so:
  ```yaml
  permissions:
    contents: write
  ```
  This grants write access to contents, and read-only for all other scopes by default. Alternatively, if finer granularity is desired, you could specify `contents: read` on the whole workflow and add `permissions: contents: write` to only the release job/step, but in this workflow there is only one job.

**Required changes:**  
- Insert `permissions:` after `name: ...` (line 1), before `on:`
- No other imports, methods, or definitions needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
