### PR TITLE
fix(agentic): fix CI compile — okhttp deps + spring-ai 2.0.0 tool API

### DIFF
--- a/dc3-common/dc3-common-agentic/pom.xml
+++ b/dc3-common/dc3-common-agentic/pom.xml
@@ -50,6 +50,20 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-model-anthropic</artifactId>
         </dependency>
+        <!-- OkHttp transport for the OpenAI/Anthropic Java SDKs. spring-ai pulls only the
+             *-java-core artifacts; the com.{openai,anthropic}.client.okhttp.* classes used by
+             ChatClientFactory live in these separate client-okhttp artifacts. Keep versions in
+             sync with the *-java-core versions that spring-ai transitively provides. -->
+        <dependency>
+            <groupId>com.openai</groupId>
+            <artifactId>openai-java-client-okhttp</artifactId>
+            <version>4.39.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.anthropic</groupId>
+            <artifactId>anthropic-java-client-okhttp</artifactId>
+            <version>2.40.1</version>
+        </dependency>
 
         <!-- DC3 Common Related -->
         <dependency>

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/config/ChatClientConfig.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/config/ChatClientConfig.java
@@ -98,7 +98,6 @@ public class ChatClientConfig {
         return ToolCallAdvisor.builder()
                 .toolCallingManager(toolCallingManager)
                 .advisorOrder(Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER + 100)
-                .streamToolCallResponses(false)
                 .build();
     }
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/service/chat/AgenticPromptBuilder.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/service/chat/AgenticPromptBuilder.java
@@ -59,7 +59,7 @@ public class AgenticPromptBuilder {
         ChatClient chatClient = chatClientFactory.getOrCreate(prepared.model());
         ChatClient.ChatClientRequestSpec promptSpec = chatClient.prompt()
                 .user(prepared.userMessage())
-                .tools(toolSpec -> toolSpec.context(prepared.toolContext()))
+                .toolContext(prepared.toolContext())
                 .advisors(advisor -> advisor.param(ChatMemory.CONVERSATION_ID, prepared.scopedConversationId()));
 
         String systemPrompt = buildSystemPrompt(prepared);
@@ -76,7 +76,7 @@ public class AgenticPromptBuilder {
         if (!prepared.toolCallingEnabled()) {
             return promptSpec;
         }
-        return promptSpec.tools(toolSpec -> toolSpec.callbacks(toolCallbackProvider)).advisors(toolCallAdvisor);
+        return promptSpec.toolCallbacks(toolCallbackProvider).advisors(toolCallAdvisor);
     }
 
     private ChatClient.ChatClientRequestSpec applyRequestOptions(ChatClient.ChatClientRequestSpec promptSpec,


### PR DESCRIPTION
## What & Why
后端 CI compile job 长期红，根因两层（均与 git-workflow 改造无关）：
1. `dc3-common-agentic` 用 `com.{openai,anthropic}.client.okhttp.*`，但 pom 只经 spring-ai 间接拿到 `*-java-core`，缺独立的 `*-java-client-okhttp` artifact（本地 .m2 有缓存故本地不暴露，CI 干净环境必红）。
2. 代码停留在 spring-ai 2.0.0-M8 的 tool API，依赖已是 2.0.0 正式版，API 不兼容。

## Changes
- pom: 显式加 `openai-java-client-okhttp:4.39.1`、`anthropic-java-client-okhttp:2.40.1`（与 spring-ai 传递的 core 版本对齐）。
- ChatClientConfig: 删除正式版已移除的 `ToolCallAdvisor.Builder.streamToolCallResponses(false)`。
- AgenticPromptBuilder: `tools(toolSpec -> toolSpec.context(..))` → `toolContext(Map)`；`tools(toolSpec -> toolSpec.callbacks(..))` → `toolCallbacks(provider)`。

## Verification
- 删本地 .m2 okhttp 缓存后从 Central 重新解析 → okhttp 报错消除。
- `mvn -DskipTests compile` 全量 75 模块 BUILD SUCCESS。
- API 用法据 spring-ai-client-chat 2.0.0 jar 字节码核验（javap）。

## Impact
- 仅 dc3-common-agentic；无对外签名变更。修复后可为 main/develop 加 CI required checks。