### PR TITLE
fix(driver): resolve 4 real defects in OPC-UA and MQTT drivers

### DIFF
--- a/dc3-driver/dc3-driver-mqtt/src/main/java/io/github/pnoker/driver/service/impl/MqttDriverCustomServiceImpl.java
+++ b/dc3-driver/dc3-driver-mqtt/src/main/java/io/github/pnoker/driver/service/impl/MqttDriverCustomServiceImpl.java
@@ -36,6 +36,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.integration.mqtt.event.MqttConnectionFailedEvent;
+import org.springframework.integration.mqtt.event.MqttIntegrationEvent;
+import org.springframework.integration.mqtt.event.MqttSubscribedEvent;
+import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -66,7 +72,7 @@ import java.util.Objects;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MqttDriverCustomServiceImpl implements DriverCustomService {
+public class MqttDriverCustomServiceImpl implements DriverCustomService, ApplicationListener<MqttIntegrationEvent> {
 
     private static final String COMMAND_TOPIC = "commandTopic";
     private static final String COMMAND_QOS = "commandQos";
@@ -75,8 +81,23 @@ public class MqttDriverCustomServiceImpl implements DriverCustomService {
     private final DriverMetadata driverMetadata;
     private final DriverSenderService driverSenderService;
     private final MqttSendService mqttSendService;
+    /**
+     * Inbound MQTT adapter. Absent when the driver runs publish-only (no
+     * {@code receive-topics} / no {@code MqttReceiveService} bean), in which case no
+     * {@link MqttIntegrationEvent} is ever published and {@link #health()} degrades to
+     * ONLINE with a diagnostic note.
+     */
+    private final ObjectProvider<MqttPahoMessageDrivenChannelAdapter> inboundAdapterProvider;
     @Value("${dc3.driver.code}")
     private String driverCode;
+
+    /**
+     * Latest known broker connection state, driven by {@link MqttSubscribedEvent} (up)
+     * and {@link MqttConnectionFailedEvent} (down) emitted by the inbound adapter.
+     * {@code null} means "no signal yet" — startup before the first connect, or a
+     * publish-only driver.
+     */
+    private volatile Boolean brokerConnected;
 
     /**
      * Initializes the MQTT driver.
@@ -103,10 +124,22 @@ public class MqttDriverCustomServiceImpl implements DriverCustomService {
     }
 
     /**
-     * Reports driver-level health based on MQTT connection status.
+     * Reports driver-level health based on the inbound MQTT broker connection.
      * <p>
-     * Process liveness is already protected by Data Center timeout scanning.
-     * This hook reports protocol-level health for the MQTT broker connection.
+     * Process liveness is already protected by Data Center timeout scanning; this hook
+     * exposes protocol-level health so the scheduler stops routing writes to an
+     * unreachable broker. The state is fed by {@link MqttIntegrationEvent}s published by
+     * the inbound adapter:
+     * </p>
+     * <ul>
+     *   <li>{@link MqttSubscribedEvent} → broker reachable and subscribed → ONLINE</li>
+     *   <li>{@link MqttConnectionFailedEvent} → broker connection lost → OFFLINE</li>
+     * </ul>
+     * <p>
+     * When the driver runs publish-only (no inbound adapter configured, i.e. no
+     * {@code receive-topics}), no events are ever published, so the driver degrades to
+     * ONLINE with a diagnostic description. The same fallback applies transiently during
+     * startup before the first connection attempt resolves.
      * </p>
      *
      * @return driver health state
@@ -114,8 +147,31 @@ public class MqttDriverCustomServiceImpl implements DriverCustomService {
      */
     @Override
     public DriverHealthState health() {
-        // TODO: implement real MQTT connection health check via MqttSendService or Spring Integration MQTT client manager
-        return DriverHealthState.online();
+        if (Objects.isNull(inboundAdapterProvider.getIfAvailable())) {
+            return DriverHealthState.builder()
+                    .description("MQTT health not actively probed: no inbound adapter configured")
+                    .build();
+        }
+        Boolean connected = brokerConnected;
+        if (Objects.isNull(connected)) {
+            return DriverHealthState.builder()
+                    .description("MQTT broker connection not yet established")
+                    .build();
+        }
+        return Boolean.TRUE.equals(connected) ? DriverHealthState.online() : DriverHealthState.offline();
+    }
+
+    @Override
+    public void onApplicationEvent(MqttIntegrationEvent event) {
+        if (event instanceof MqttSubscribedEvent) {
+            brokerConnected = Boolean.TRUE;
+            log.info("MQTT broker connected and subscribed, protocol={}, source={}", driverCode,
+                    Objects.toString(event.getSource(), "?"));
+        } else if (event instanceof MqttConnectionFailedEvent) {
+            brokerConnected = Boolean.FALSE;
+            log.warn("MQTT broker connection failed, protocol={}, source={}", driverCode,
+                    Objects.toString(event.getSource(), "?"));
+        }
     }
 
     /**

--- a/dc3-driver/dc3-driver-mqtt/src/test/java/io/github/pnoker/driver/service/impl/MqttDriverCustomServiceImplTest.java
+++ b/dc3-driver/dc3-driver-mqtt/src/test/java/io/github/pnoker/driver/service/impl/MqttDriverCustomServiceImplTest.java
@@ -17,6 +17,7 @@
 
 package io.github.pnoker.driver.service.impl;
 
+import io.github.pnoker.common.driver.entity.bean.DriverHealthState;
 import io.github.pnoker.common.driver.entity.bean.WritePointValue;
 import io.github.pnoker.common.driver.entity.bo.AttributeBO;
 import io.github.pnoker.common.driver.entity.bo.DeviceBO;
@@ -25,6 +26,7 @@ import io.github.pnoker.common.driver.metadata.DriverMetadata;
 import io.github.pnoker.common.driver.service.DriverSenderService;
 import io.github.pnoker.common.entity.dto.MetadataEventDTO;
 import io.github.pnoker.common.enums.AttributeTypeEnum;
+import io.github.pnoker.common.enums.EntityStatusEnum;
 import io.github.pnoker.common.enums.MetadataOperateTypeEnum;
 import io.github.pnoker.common.enums.MetadataTypeEnum;
 import io.github.pnoker.common.enums.PointTypeEnum;
@@ -34,6 +36,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.integration.mqtt.event.MqttConnectionFailedEvent;
+import org.springframework.integration.mqtt.event.MqttSubscribedEvent;
+import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,9 +47,12 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MqttDriverCustomServiceImplTest {
@@ -79,9 +88,24 @@ class MqttDriverCustomServiceImplTest {
         return event;
     }
 
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<MqttPahoMessageDrivenChannelAdapter> adapterProvider(
+            MqttPahoMessageDrivenChannelAdapter adapter) {
+        ObjectProvider<MqttPahoMessageDrivenChannelAdapter> provider = mock(ObjectProvider.class);
+        lenient().when(provider.getIfAvailable()).thenReturn(adapter);
+        return provider;
+    }
+
     @BeforeEach
     void setUp() {
-        service = new MqttDriverCustomServiceImpl(driverMetadata, driverSenderService, mqttSendService);
+        // Publish-only driver: no inbound adapter configured.
+        service = new MqttDriverCustomServiceImpl(driverMetadata, driverSenderService, mqttSendService,
+                adapterProvider(null));
+    }
+
+    private MqttDriverCustomServiceImpl serviceWithAdapter() {
+        return new MqttDriverCustomServiceImpl(driverMetadata, driverSenderService, mqttSendService,
+                adapterProvider(mock(MqttPahoMessageDrivenChannelAdapter.class)));
     }
 
     @Test
@@ -154,6 +178,40 @@ class MqttDriverCustomServiceImplTest {
 
         assertThat(ok).isTrue();
         verify(mqttSendService).sendToMqtt("dc3/cmd/temp", "23.5");
+    }
+
+    @Test
+    void healthReportsOfflineWhenAdapterDisconnected() {
+        MqttDriverCustomServiceImpl svc = serviceWithAdapter();
+        // Inbound adapter emits MqttConnectionFailedEvent when the broker drops.
+        svc.onApplicationEvent(new MqttConnectionFailedEvent(new Object(), new RuntimeException("broker down")));
+
+        DriverHealthState health = svc.health();
+
+        assertThat(health.getStatus()).isEqualTo(EntityStatusEnum.OFFLINE);
+        assertThat(health.getDescription()).isNull();
+    }
+
+    @Test
+    void healthReportsOnlineWhenAdapterConnectedAndRunning() {
+        MqttDriverCustomServiceImpl svc = serviceWithAdapter();
+        // Inbound adapter emits MqttSubscribedEvent once connected and subscribed.
+        svc.onApplicationEvent(new MqttSubscribedEvent(new Object(), "subscribed"));
+
+        DriverHealthState health = svc.health();
+
+        assertThat(health.getStatus()).isEqualTo(EntityStatusEnum.ONLINE);
+        assertThat(health.getDescription()).isNull();
+    }
+
+    @Test
+    void healthFallsBackToOnlineWhenNoAdapterConfigured() {
+        // service built in setUp() uses adapterProvider(null) — publish-only driver.
+
+        DriverHealthState health = service.health();
+
+        assertThat(health.getStatus()).isEqualTo(EntityStatusEnum.ONLINE);
+        assertThat(health.getDescription()).contains("no inbound adapter");
     }
 
 }

--- a/dc3-driver/dc3-driver-opc-ua/src/main/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImpl.java
+++ b/dc3-driver/dc3-driver-opc-ua/src/main/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImpl.java
@@ -87,11 +87,25 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
     private static final long REQUEST_TIMEOUT_MS = 5000;
     private static final long READ_TIMEOUT_SECONDS = 1;
     private static final long WRITE_TIMEOUT_SECONDS = 1;
+    /**
+     * Max consecutive connection failures before entering backoff, mirroring the
+     * Modbus TCP driver. Stops connect storms against unreachable OPC UA servers.
+     */
+    private static final int FAILURE_BACKOFF_THRESHOLD = 3;
+    /**
+     * Backoff duration in milliseconds after exceeding the failure threshold.
+     */
+    private static final long FAILURE_BACKOFF_MS = 60_000;
     private final DriverMetadata driverMetadata;
     private final DriverSenderService driverSenderService;
     @Value("${dc3.driver.code}")
     private String driverCode;
     private Map<Long, OpcUaClient> connectMap;
+    /**
+     * Failure tracking for connection backoff to prevent repeated TCP+TLS handshake
+     * attempts to unreachable devices on every schedule cycle.
+     */
+    private Map<Long, ConsecutiveFailure> failureMap;
 
     /**
      * KeyLoader for OPC UA client certificate management.
@@ -119,6 +133,7 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
     @Override
     public void initial() {
         connectMap = new ConcurrentHashMap<>(16);
+        failureMap = new ConcurrentHashMap<>(16);
         try {
             keyLoader = new KeyLoader().load(
                     java.nio.file.Path.of(System.getProperty("user.dir"), "dc3", "opc-ua"));
@@ -150,7 +165,10 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
                 return DeviceHealthState.online();
             }
         } catch (Exception e) {
-            log.debug("Health check failed for device {}", device.getId(), e);
+            log.warn("Driver health check failed, protocol={}, deviceId={}", driverCode, device.getId(), e);
+            // A failed health probe means the cached client (if any) is stale or broken;
+            // drop it so the next cycle rebuilds from scratch instead of reusing it.
+            invalidateConnector(device.getId());
         }
         return DeviceHealthState.offline();
     }
@@ -202,6 +220,14 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
      * @throws ConnectorException if client creation fails
      */
     private OpcUaClient getConnector(Long deviceId, Map<String, AttributeBO> driverConfig) {
+        // Check backoff before attempting connection to avoid TCP+TLS handshake storms
+        ConsecutiveFailure failure = failureMap.get(deviceId);
+        if (failure != null && failure.shouldBackoff()) {
+            throw new ConnectorException(
+                    "Driver connection in backoff after {} consecutive failures, protocol={}, deviceId={}",
+                    failure.count, driverCode, deviceId);
+        }
+
         return connectMap.computeIfAbsent(deviceId, id -> {
             String host = driverConfig.get("host").getValue(String.class);
             int port = driverConfig.get("port").getValue(Integer.class);
@@ -229,11 +255,16 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
                             }
                             return configBuilder.build();
                         });
+                // Successful connection clears failure tracking
+                failureMap.remove(deviceId);
                 log.info("Driver connection created, protocol={}, deviceId={}, host={}, port={}, path={}, identity={}",
                         driverCode, deviceId, host, port, path,
                         identityProvider instanceof X509IdentityProvider ? "x509" : "anonymous");
                 return opcUaClient;
             } catch (UaException e) {
+                // Record failure for backoff
+                failureMap.compute(deviceId, (k, v) ->
+                        v == null ? new ConsecutiveFailure() : v.increment());
                 log.error("Driver connection failed, protocol={}, deviceId={}, host={}, port={}, path={}", driverCode, deviceId,
                         host, port, path, e);
                 throw new ConnectorException("Driver connection failed, protocol=" + driverCode + ", deviceId={}, host={}, port={}, path={}, message={}",
@@ -399,6 +430,21 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
         }
     }
 
+    /**
+     * Invalidate any cached client for the given device. Used by {@link #health} where
+     * only the device id is known (the failing client reference is local to the try block).
+     * Falls back to {@link #invalidateConnector(Long, OpcUaClient) the two-arg form} when a
+     * cached entry exists, so the value-matched remove + disconnect still applies.
+     *
+     * @param deviceId unique device identifier
+     */
+    private void invalidateConnector(Long deviceId) {
+        OpcUaClient cached = connectMap.remove(deviceId);
+        if (cached != null) {
+            invalidateConnector(deviceId, cached);
+        }
+    }
+
     @Override
     public ValidationReport validate(Map<String, AttributeBO> driverConfig) {
         List<ValidationReport.AttributeIssue> issues = new ArrayList<>();
@@ -417,6 +463,35 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
         return ValidationReport.builder()
                 .passed(issues.stream().noneMatch(i -> i.getLevel() == ValidationReport.IssueLevel.ERROR))
                 .issues(issues).build();
+    }
+
+    /**
+     * Tracks consecutive connection failures for backoff. Mirrors the Modbus TCP driver
+     * implementation. Immutable after construction; {@link #increment()} returns a new
+     * instance so {@link ConcurrentHashMap#compute} updates stay race-free.
+     */
+    private static class ConsecutiveFailure {
+        final int count;
+        final long firstFailureTime;
+
+        ConsecutiveFailure() {
+            this.count = 1;
+            this.firstFailureTime = System.currentTimeMillis();
+        }
+
+        ConsecutiveFailure(int count, long firstFailureTime) {
+            this.count = count;
+            this.firstFailureTime = firstFailureTime;
+        }
+
+        ConsecutiveFailure increment() {
+            return new ConsecutiveFailure(count + 1, firstFailureTime);
+        }
+
+        boolean shouldBackoff() {
+            return count >= FAILURE_BACKOFF_THRESHOLD
+                    && (System.currentTimeMillis() - firstFailureTime) < FAILURE_BACKOFF_MS;
+        }
     }
 
 }

--- a/dc3-driver/dc3-driver-opc-ua/src/main/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImpl.java
+++ b/dc3-driver/dc3-driver-opc-ua/src/main/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImpl.java
@@ -31,6 +31,7 @@ import io.github.pnoker.common.entity.dto.MetadataEventDTO;
 import io.github.pnoker.common.enums.MetadataOperateTypeEnum;
 import io.github.pnoker.common.enums.MetadataTypeEnum;
 import io.github.pnoker.common.enums.PointTypeEnum;
+import io.github.pnoker.common.enums.EntityStatusEnum;
 import io.github.pnoker.common.exception.ConnectorException;
 import io.github.pnoker.common.exception.ReadPointException;
 import io.github.pnoker.common.exception.UnSupportException;
@@ -96,6 +97,13 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
      */
     private volatile KeyLoader keyLoader;
 
+    /**
+     * Set when {@link KeyLoader} initialization failed in {@link #initial()} and the
+     * driver fell back to anonymous auth. Surfaced in {@link #health} description so
+     * operators can see the driver is running in degraded certificate mode.
+     */
+    private volatile boolean certificateDegraded;
+
     private static void checkRequired(Map<String, AttributeBO> config, String code,
                                       List<ValidationReport.AttributeIssue> issues) {
         AttributeBO attr = config.get(code);
@@ -115,6 +123,7 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
         } catch (Exception e) {
             log.warn("OPC UA KeyLoader initialization failed, falling back to anonymous auth", e);
             keyLoader = null;
+            certificateDegraded = true;
         }
     }
 
@@ -130,6 +139,12 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
             if (client != null) {
                 // Connect is idempotent — returns immediately when already connected
                 client.connect().get(1, TimeUnit.SECONDS);
+                if (certificateDegraded) {
+                    return DeviceHealthState.builder()
+                            .status(EntityStatusEnum.ONLINE)
+                            .description("OPC UA running in degraded mode: certificate unavailable, using anonymous auth")
+                            .build();
+                }
                 return DeviceHealthState.online();
             }
         } catch (Exception e) {

--- a/dc3-driver/dc3-driver-opc-ua/src/main/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImpl.java
+++ b/dc3-driver/dc3-driver-opc-ua/src/main/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImpl.java
@@ -41,6 +41,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider;
+import org.eclipse.milo.opcua.sdk.client.api.identity.IdentityProvider;
+import org.eclipse.milo.opcua.sdk.client.api.identity.X509IdentityProvider;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -210,26 +212,26 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
             try {
                 // Prefer certificate-based auth when KeyLoader is available
                 KeyLoader loader = this.keyLoader;
+                IdentityProvider identityProvider = buildIdentityProvider(loader);
                 OpcUaClient opcUaClient = OpcUaClient.create(url, endpoints -> endpoints.stream().findFirst(),
                         configBuilder -> {
                             configBuilder
                                     .setRequestTimeout(Unsigned.uint(REQUEST_TIMEOUT_MS))
                                     .setApplicationName(LocalizedText.english("IoT DC3 OPC UA Driver"))
                                     .setApplicationUri("urn:dc3:opc:ua:client");
-                            if (loader != null && loader.getClientCertificate() != null
-                                    && loader.getClientKeyPair() != null) {
+                            if (identityProvider instanceof X509IdentityProvider) {
                                 configBuilder
                                         .setCertificate(loader.getClientCertificate())
                                         .setKeyPair(loader.getClientKeyPair())
-                                        .setIdentityProvider(new AnonymousProvider());
+                                        .setIdentityProvider(identityProvider);
                             } else {
-                                configBuilder
-                                        .setIdentityProvider(new AnonymousProvider());
+                                configBuilder.setIdentityProvider(identityProvider);
                             }
                             return configBuilder.build();
                         });
-                log.info("Driver connection created, protocol={}, deviceId={}, host={}, port={}, path={}", driverCode, deviceId,
-                        host, port, path);
+                log.info("Driver connection created, protocol={}, deviceId={}, host={}, port={}, path={}, identity={}",
+                        driverCode, deviceId, host, port, path,
+                        identityProvider instanceof X509IdentityProvider ? "x509" : "anonymous");
                 return opcUaClient;
             } catch (UaException e) {
                 log.error("Driver connection failed, protocol={}, deviceId={}, host={}, port={}, path={}", driverCode, deviceId,
@@ -238,6 +240,26 @@ public class OpcUaDriverCustomServiceImpl implements DriverCustomService {
                         deviceId, host, port, path, e.getMessage(), e);
             }
         });
+    }
+
+    /**
+     * Choose the OPC UA application-layer identity provider based on whether the
+     * KeyLoader produced a usable client certificate and key pair.
+     * <p>
+     * When the loader carries a certificate and key pair, an {@link X509IdentityProvider}
+     * is returned so the certificate is used for both TLS and user-token authentication.
+     * Otherwise an {@link AnonymousProvider} is returned. Extracted so the branch choice
+     * can be unit-tested without standing up a full OPC UA client configBuilder.
+     *
+     * @param loader the KeyLoader (may be {@code null} when initialization failed)
+     * @return an X509IdentityProvider when a certificate is present, else AnonymousProvider
+     */
+    private IdentityProvider buildIdentityProvider(KeyLoader loader) {
+        if (loader != null && loader.getClientCertificate() != null && loader.getClientKeyPair() != null) {
+            log.info("Configuring OPC UA client with X.509 certificate identity");
+            return new X509IdentityProvider(loader.getClientCertificate(), loader.getClientKeyPair().getPrivate());
+        }
+        return new AnonymousProvider();
     }
 
     /**

--- a/dc3-driver/dc3-driver-opc-ua/src/test/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImplTest.java
+++ b/dc3-driver/dc3-driver-opc-ua/src/test/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImplTest.java
@@ -31,7 +31,11 @@ import io.github.pnoker.common.enums.MetadataOperateTypeEnum;
 import io.github.pnoker.common.enums.MetadataTypeEnum;
 import io.github.pnoker.common.enums.PointTypeEnum;
 import io.github.pnoker.common.exception.ConnectorException;
+import io.github.pnoker.driver.key.KeyLoader;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider;
+import org.eclipse.milo.opcua.sdk.client.api.identity.IdentityProvider;
+import org.eclipse.milo.opcua.sdk.client.api.identity.X509IdentityProvider;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -46,6 +50,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -227,8 +235,40 @@ class OpcUaDriverCustomServiceImplTest {
         assertThat(ok).isTrue();
     }
 
+    @Test
+    void certificateBranchUsesX509IdentityProvider() throws Exception {
+        // A loader carrying both a client certificate and a key pair must produce an
+        // X509IdentityProvider so the certificate is used for application-layer auth,
+        // not just TLS.
+        KeyPair keyPair = Mockito.mock(KeyPair.class);
+        Mockito.when(keyPair.getPrivate()).thenReturn(Mockito.mock(PrivateKey.class));
+        KeyLoader loader = Mockito.mock(KeyLoader.class);
+        Mockito.when(loader.getClientCertificate()).thenReturn(Mockito.mock(X509Certificate.class));
+        Mockito.when(loader.getClientKeyPair()).thenReturn(keyPair);
+
+        IdentityProvider provider = invokeBuildIdentityProvider(loader);
+
+        assertThat(provider).isInstanceOf(X509IdentityProvider.class);
+    }
+
+    @Test
+    void noCertificateBranchUsesAnonymous() throws Exception {
+        // No loader (initial() fell back to anonymous) must yield AnonymousProvider.
+        assertThat(invokeBuildIdentityProvider(null)).isInstanceOf(AnonymousProvider.class);
+
+        // A loader without a certificate or key pair must also yield AnonymousProvider.
+        KeyLoader empty = Mockito.mock(KeyLoader.class);
+        assertThat(invokeBuildIdentityProvider(empty)).isInstanceOf(AnonymousProvider.class);
+    }
+
+    private IdentityProvider invokeBuildIdentityProvider(KeyLoader loader) throws Exception {
+        Method method = OpcUaDriverCustomServiceImpl.class.getDeclaredMethod("buildIdentityProvider", KeyLoader.class);
+        method.setAccessible(true);
+        return (IdentityProvider) method.invoke(service, loader);
+    }
+
     private void invokeGetConnector(Long deviceId, Map<String, AttributeBO> driverConfig) throws Exception {
-        java.lang.reflect.Method method =
+        Method method =
                 OpcUaDriverCustomServiceImpl.class.getDeclaredMethod("getConnector", Long.class, Map.class);
         method.setAccessible(true);
         method.invoke(service, deviceId, driverConfig);

--- a/dc3-driver/dc3-driver-opc-ua/src/test/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImplTest.java
+++ b/dc3-driver/dc3-driver-opc-ua/src/test/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImplTest.java
@@ -17,6 +17,7 @@
 
 package io.github.pnoker.driver.service.impl;
 
+import io.github.pnoker.common.driver.entity.bean.DeviceHealthState;
 import io.github.pnoker.common.driver.entity.bean.WritePointValue;
 import io.github.pnoker.common.driver.entity.bo.AttributeBO;
 import io.github.pnoker.common.driver.entity.bo.DeviceBO;
@@ -25,6 +26,7 @@ import io.github.pnoker.common.driver.metadata.DriverMetadata;
 import io.github.pnoker.common.driver.service.DriverSenderService;
 import io.github.pnoker.common.entity.dto.MetadataEventDTO;
 import io.github.pnoker.common.enums.AttributeTypeEnum;
+import io.github.pnoker.common.enums.EntityStatusEnum;
 import io.github.pnoker.common.enums.MetadataOperateTypeEnum;
 import io.github.pnoker.common.enums.MetadataTypeEnum;
 import io.github.pnoker.common.enums.PointTypeEnum;
@@ -230,6 +232,38 @@ class OpcUaDriverCustomServiceImplTest {
                 OpcUaDriverCustomServiceImpl.class.getDeclaredMethod("getConnector", Long.class, Map.class);
         method.setAccessible(true);
         method.invoke(service, deviceId, driverConfig);
+    }
+
+    @Test
+    void healthReportsDegradedModeWhenKeyLoaderFailed() throws Exception {
+        setCertificateDegraded(true);
+        OpcUaClient client = Mockito.mock(OpcUaClient.class);
+        Mockito.when(client.connect()).thenReturn(CompletableFuture.completedFuture(client));
+        connectionMap().put(1L, client);
+
+        DeviceHealthState state = service.health(driverConfig("h", 4840, "/"), device(1L));
+
+        assertThat(state.getStatus()).isEqualTo(EntityStatusEnum.ONLINE);
+        assertThat(state.getDescription()).isNotNull().contains("degraded");
+    }
+
+    @Test
+    void healthReportsOnlineWhenNotDegraded() throws Exception {
+        setCertificateDegraded(false);
+        OpcUaClient client = Mockito.mock(OpcUaClient.class);
+        Mockito.when(client.connect()).thenReturn(CompletableFuture.completedFuture(client));
+        connectionMap().put(2L, client);
+
+        DeviceHealthState state = service.health(driverConfig("h", 4840, "/"), device(2L));
+
+        assertThat(state.getStatus()).isEqualTo(EntityStatusEnum.ONLINE);
+        assertThat(state.getDescription()).isNull();
+    }
+
+    private void setCertificateDegraded(boolean value) throws Exception {
+        Field field = OpcUaDriverCustomServiceImpl.class.getDeclaredField("certificateDegraded");
+        field.setAccessible(true);
+        field.setBoolean(service, value);
     }
 
     @SuppressWarnings("unchecked")

--- a/dc3-driver/dc3-driver-opc-ua/src/test/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImplTest.java
+++ b/dc3-driver/dc3-driver-opc-ua/src/test/java/io/github/pnoker/driver/service/impl/OpcUaDriverCustomServiceImplTest.java
@@ -300,6 +300,60 @@ class OpcUaDriverCustomServiceImplTest {
         assertThat(state.getDescription()).isNull();
     }
 
+    @Test
+    void connectorEntersBackoffAfterConsecutiveFailures() throws Exception {
+        // Mirror of the Modbus TCP behaviour: after FAILURE_BACKOFF_THRESHOLD (3)
+        // consecutive create() failures, the next getConnector must short-circuit
+        // with a backoff ConnectorException instead of attempting another TCP+TLS
+        // handshake. invokeGetConnector calls the private method via reflection, so
+        // the thrown ConnectorException is wrapped by InvocationTargetException —
+        // assert on the root cause.
+        try (MockedStatic<OpcUaClient> staticMock = Mockito.mockStatic(OpcUaClient.class)) {
+            staticMock.when(() -> OpcUaClient.create(anyString(),
+                    any(Function.class),
+                    any(Function.class))).thenThrow(new UaException(0L, "endpoint refused"));
+
+            // Three failures accumulate into failureMap (threshold reached).
+            for (int i = 0; i < 3; i++) {
+                assertThatThrownBy(() -> invokeGetConnector(7L, driverConfig("unreachable", 4840, "/")))
+                        .hasCauseInstanceOf(ConnectorException.class)
+                        .cause()
+                        .isInstanceOf(ConnectorException.class)
+                        .hasMessageContaining("endpoint refused");
+            }
+            assertThat(failureMap()).containsKey(7L);
+
+            // Fourth attempt must short-circuit with a backoff message, not re-invoke create.
+            assertThatThrownBy(() -> invokeGetConnector(7L, driverConfig("unreachable", 4840, "/")))
+                    .hasCauseInstanceOf(ConnectorException.class)
+                    .cause()
+                    .hasMessageContaining("backoff");
+
+            // Backoff path must NOT have touched OpcUaClient.create again (3 invocations, not 4).
+            staticMock.verify(() -> OpcUaClient.create(anyString(),
+                    any(Function.class),
+                    any(Function.class)), times(3));
+        }
+    }
+
+    @Test
+    void healthFailureInvalidatesCachedClient() throws Exception {
+        // A cached client whose connect() probe fails must be removed from connectMap so
+        // the next cycle rebuilds from scratch, and health must report OFFLINE.
+        OpcUaClient badClient = Mockito.mock(OpcUaClient.class);
+        Mockito.when(badClient.connect())
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("connection reset")));
+        connectionMap().put(9L, badClient);
+        assertThat(connectionMap()).containsKey(9L);
+
+        DeviceHealthState state = service.health(driverConfig("h", 4840, "/"), device(9L));
+
+        assertThat(state.getStatus()).isEqualTo(EntityStatusEnum.OFFLINE);
+        assertThat(connectionMap()).doesNotContainKey(9L);
+        // Disconnect is best-effort but should have been attempted on the now-stale client.
+        Mockito.verify(badClient).disconnect();
+    }
+
     private void setCertificateDegraded(boolean value) throws Exception {
         Field field = OpcUaDriverCustomServiceImpl.class.getDeclaredField("certificateDegraded");
         field.setAccessible(true);
@@ -311,6 +365,13 @@ class OpcUaDriverCustomServiceImplTest {
         Field field = OpcUaDriverCustomServiceImpl.class.getDeclaredField("connectMap");
         field.setAccessible(true);
         return (Map<Long, OpcUaClient>) field.get(service);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Long, Object> failureMap() throws Exception {
+        Field field = OpcUaDriverCustomServiceImpl.class.getDeclaredField("failureMap");
+        field.setAccessible(true);
+        return (Map<Long, Object>) field.get(service);
     }
 
 }


### PR DESCRIPTION
## 修复协议层 4 条真缺陷

修复 `protocol-defects.md`（见关联分支 `feature/docs-protocol-layer-slice`）分析出的 D1-D4，全部在 OPC-UA 驱动 + MQTT health。

| 缺陷 | commit | 修复 |
|---|---|---|
| D4 MQTT health 撒谎 | `f69787eb8` | 事件驱动（MqttSubscribedEvent/MqttConnectionFailedEvent），health 基于真实连接 |
| D2 OPC-UA 静默降级 | `2d78b55` | certificateDegraded 标记 + health description 暴露降级 |
| D3 OPC-UA 证书空设 | `94feac5c6` | 提取 buildIdentityProvider，证书分支用 X509IdentityProvider（Milo 签名 cert+PrivateKey） |
| D1 OPC-UA 连接风暴 | `63fdf962d` | 镜像 modbus-tcp failureMap+ConsecutiveFailure（阈值3/60s）+ health invalidate 坏 client |

### 测试
- `dc3-driver-mqtt`: 16/16 BUILD SUCCESS
- `dc3-driver-opc-ua`: 16/16 BUILD SUCCESS（含 D1 退避 + D2 降级 + D3 x509 全部测试）

### 说明
D3 为 breaking change（X509IdentityProvider）：目标服务器若仅 TLS 验证 + 应用层 username/password，需确认兼容。