### PR TITLE
fix(tenant): bind tenant context on gRPC server paths

### DIFF
--- a/dc3-api/dc3-api-driver/src/main/protobuf/api/common/driver/driver_query.proto
+++ b/dc3-api/dc3-api-driver/src/main/protobuf/api/common/driver/driver_query.proto
@@ -29,6 +29,9 @@ option java_multiple_files = true;
 message GrpcDriverQuery {
   // Identifier of the specific driver instance
   int64 driver_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Device query structure used to query device-related information
@@ -38,6 +41,9 @@ message GrpcDeviceQuery {
 
   // Identifier of the specific device
   int64 device_id = 2;
+
+  // Identifies the tenant
+  int64 tenant_id = 3;
 }
 
 // Point query structure used to query point-related information
@@ -47,4 +53,7 @@ message GrpcPointQuery {
 
   // Identifier of the specific point
   int64 point_id = 2;
+
+  // Identifies the tenant
+  int64 tenant_id = 3;
 }

--- a/dc3-api/dc3-api-manager/src/main/protobuf/api/center/manager/manager_query.proto
+++ b/dc3-api/dc3-api-manager/src/main/protobuf/api/center/manager/manager_query.proto
@@ -29,67 +29,102 @@ option java_multiple_files = true;
 message GrpcDriverQuery {
   // Identifies specific driver instance
   int64 driver_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Driver ids query structure for batch driver lookup
 message GrpcDriverIdsQuery {
   // Identifies driver instances
   repeated int64 driver_ids = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Profile template query structure for querying template information by profile ID
 message GrpcProfileQuery {
   // Profile template ID that identifies specific configuration template
   int64 profile_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Profile ids query structure for batch profile lookup
 message GrpcProfileIdsQuery {
   // Identifies profile template instances
   repeated int64 profile_ids = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Point query structure for querying point information by point ID
 message GrpcPointQuery {
   // Point ID that identifies specific point
   int64 point_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Point ids query structure for batch point lookup
 message GrpcPointIdsQuery {
   // Identifies point instances
   repeated int64 point_ids = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Command query structure for querying command information by command ID
 message GrpcCommandQuery {
   int64 command_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Command ids query structure for batch command lookup
 message GrpcCommandIdsQuery {
   repeated int64 command_ids = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Event query structure for querying event information by event ID
 message GrpcEventQuery {
   int64 event_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Event ids query structure for batch event lookup
 message GrpcEventIdsQuery {
   repeated int64 event_ids = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Device query structure for querying device information by device ID
 message GrpcDeviceQuery {
   // Device ID that identifies specific device
   int64 device_id = 1;
+
+  // Identifies the tenant
+  int64 tenant_id = 2;
 }
 
 // Device ids query structure for batch device lookup
 message GrpcDeviceIdsQuery {
   // Identifies device instances
   repeated int64 device_ids = 1;
-}
 
+  // Identifies the tenant
+  int64 tenant_id = 2;
+}

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/TokenServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/TokenServer.java
@@ -24,6 +24,7 @@ import io.github.pnoker.api.common.GrpcRFactory;
 import io.github.pnoker.common.auth.biz.TokenService;
 import io.github.pnoker.common.auth.entity.bean.TokenValid;
 import io.github.pnoker.common.enums.ErrorCode;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.github.pnoker.common.utils.TimeUtil;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
@@ -51,8 +52,12 @@ public class TokenServer extends TokenApiGrpc.TokenApiImplBase {
         GrpcRTokenDTO.Builder builder = GrpcRTokenDTO.newBuilder();
 
         try {
-            TokenValid entity = tokenService.checkValid(request.getName(), request.getSalt(), request.getToken(),
-                    request.getTenant());
+            // Login path: validate the principal before a tenant context is bound to this
+            // thread. checkValid resolves tenant, credential, and tenant-membership; the
+            // membership lookup reads dc3_tenant_membership (tenant_id-bearing, not
+            // whitelisted), so run it with tenant filtering disabled.
+            TokenValid entity = TenantContextHolder.runIgnore(() -> tokenService.checkValid(request.getName(),
+                    request.getSalt(), request.getToken(), request.getTenant()));
             if (Objects.isNull(entity)) {
                 builder.setResult(GrpcRFactory.notFound());
             } else if (!entity.isValid()) {

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/impl/DeviceAlarmServiceImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/impl/DeviceAlarmServiceImpl.java
@@ -68,26 +68,24 @@ public class DeviceAlarmServiceImpl implements DeviceAlarmService {
             return;
         }
 
-        FacadeDeviceBO device = null;
         Long tenantId = entityDTO.getTenantId();
+        if (Objects.isNull(tenantId) || tenantId <= 0) {
+            // Tenant id must be supplied by the upstream alarm source (driver report, timeout
+            // check, state scan). The fail-closed tenant-line interceptor rejects unscoped
+            // queries, so the tenant can no longer be reverse-resolved from the device — drop
+            // instead of silently persisting with tenant_id=0.
+            log.warn("Drop device alarm because tenantId is missing, deviceId={}", entityDTO.getDeviceId());
+            return;
+        }
         Long driverId = entityDTO.getDriverId();
-        if (Objects.isNull(tenantId) || tenantId <= 0 || Objects.isNull(driverId) || driverId <= 0) {
-            device = deviceFacade.getById(entityDTO.getDeviceId());
+        FacadeDeviceBO device = null;
+        if (Objects.isNull(driverId) || driverId <= 0) {
+            device = deviceFacade.getById(tenantId, entityDTO.getDeviceId());
             if (Objects.isNull(device)) {
-                log.warn("Drop device alarm because device[{}] is not found in metadata; tenant context unavailable",
-                        entityDTO.getDeviceId());
+                log.warn("Drop device alarm because device[{}] is not found in metadata", entityDTO.getDeviceId());
                 return;
             }
-            if (Objects.isNull(tenantId) || tenantId <= 0) {
-                tenantId = device.getTenantId();
-            }
-            if (Objects.isNull(driverId) || driverId <= 0) {
-                driverId = device.getDriverId();
-            }
-        }
-        if (Objects.isNull(tenantId) || tenantId <= 0) {
-            log.warn("Drop device alarm because tenantId could not be resolved, deviceId={}", entityDTO.getDeviceId());
-            return;
+            driverId = device.getDriverId();
         }
         entityDTO.setTenantId(tenantId);
         entityDTO.setDriverId(Objects.requireNonNullElse(driverId, 0L));

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/impl/DriverAlarmServiceImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/impl/DriverAlarmServiceImpl.java
@@ -27,8 +27,6 @@ import io.github.pnoker.common.enums.AlarmMessageLevelEnum;
 import io.github.pnoker.common.enums.AlarmSourceTypeEnum;
 import io.github.pnoker.common.enums.AlarmTargetTypeEnum;
 import io.github.pnoker.common.enums.AlarmTypeEnum;
-import io.github.pnoker.common.facade.api.DriverFacade;
-import io.github.pnoker.common.facade.entity.bo.FacadeDriverBO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -54,8 +52,6 @@ public class DriverAlarmServiceImpl implements DriverAlarmService {
 
     private final AlarmRuleTriggerService alarmRuleTriggerService;
 
-    private final DriverFacade driverFacade;
-
     @Override
     public void alarm(DriverAlarmDTO entityDTO) {
         if (Objects.isNull(entityDTO) || Objects.isNull(entityDTO.getDriverId())) {
@@ -65,16 +61,9 @@ public class DriverAlarmServiceImpl implements DriverAlarmService {
 
         Long tenantId = entityDTO.getTenantId();
         if (Objects.isNull(tenantId) || tenantId <= 0) {
-            FacadeDriverBO driver = driverFacade.getById(entityDTO.getDriverId());
-            if (Objects.isNull(driver)) {
-                log.warn("Drop driver alarm because driver[{}] is not found in metadata; tenant context unavailable",
-                        entityDTO.getDriverId());
-                return;
-            }
-            tenantId = driver.getTenantId();
-        }
-        if (Objects.isNull(tenantId) || tenantId <= 0) {
-            log.warn("Drop driver alarm because tenantId could not be resolved, driverId={}", entityDTO.getDriverId());
+            // See DeviceAlarmServiceImpl: tenant must come from the upstream source; the
+            // fail-closed interceptor forbids reverse-resolving it from the driver.
+            log.warn("Drop driver alarm because tenantId is missing, driverId={}", entityDTO.getDriverId());
             return;
         }
         entityDTO.setTenantId(tenantId);

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/CommandHistoryServer.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/CommandHistoryServer.java
@@ -34,6 +34,7 @@ import io.github.pnoker.common.data.entity.vo.CommandHistoryQueryVO;
 import io.github.pnoker.common.data.entity.vo.CommandHistoryVO;
 import io.github.pnoker.common.enums.ErrorCode;
 import io.github.pnoker.common.enums.PointCommandStatusEnum;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.github.pnoker.common.utils.GrpcBuilderUtil;
 import io.github.pnoker.common.utils.JsonUtil;
 import io.grpc.stub.StreamObserver;
@@ -63,6 +64,7 @@ public class CommandHistoryServer extends CommandHistoryApiGrpc.CommandHistoryAp
 
     @Override
     public void callCommand(GrpcCommandCallVO request, StreamObserver<GrpcRString> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             CommandCallBO entityBO = new CommandCallBO();
             entityBO.setDeviceId(request.getDeviceId());
@@ -81,13 +83,17 @@ public class CommandHistoryServer extends CommandHistoryApiGrpc.CommandHistoryAp
                     .setResult(GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage()))
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 
     @Override
     public void getByRecordId(GrpcStringQuery request, StreamObserver<GrpcRCommandHistoryDTO> responseObserver) {
         try {
-            CommandHistoryVO record = commandHistoryService.getByRecordId(request.getValue());
+            // record_id is globally unique but dc3_command_history is not tenant-whitelisted;
+            // the GrpcStringQuery carries no tenant_id, so bypass tenant filtering here.
+            CommandHistoryVO record = TenantContextHolder.runIgnore(() -> commandHistoryService.getByRecordId(request.getValue()));
             GrpcRCommandHistoryDTO.Builder response = GrpcRCommandHistoryDTO.newBuilder();
 
             if (Objects.nonNull(record)) {
@@ -109,6 +115,7 @@ public class CommandHistoryServer extends CommandHistoryApiGrpc.CommandHistoryAp
 
     @Override
     public void listByPage(GrpcCommandHistoryQuery request, StreamObserver<GrpcRPageCommandHistoryDTO> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             CommandHistoryQueryVO queryVO = new CommandHistoryQueryVO();
             queryVO.setDeviceId(request.getDeviceId() != 0 ? request.getDeviceId() : null);
@@ -139,6 +146,8 @@ public class CommandHistoryServer extends CommandHistoryApiGrpc.CommandHistoryAp
                     .setResult(GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage()))
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/EventHistoryServer.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/EventHistoryServer.java
@@ -34,6 +34,7 @@ import io.github.pnoker.common.data.entity.vo.EventHistoryQueryVO;
 import io.github.pnoker.common.data.entity.vo.EventHistoryVO;
 import io.github.pnoker.common.enums.ErrorCode;
 import io.github.pnoker.common.enums.EventTypeFlagEnum;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.github.pnoker.common.utils.GrpcBuilderUtil;
 import io.github.pnoker.common.utils.JsonUtil;
 import io.grpc.stub.StreamObserver;
@@ -63,6 +64,7 @@ public class EventHistoryServer extends EventHistoryApiGrpc.EventHistoryApiImplB
 
     @Override
     public void reportEvent(GrpcEventReportVO request, StreamObserver<GrpcRString> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             EventReportBO entityBO = new EventReportBO();
             entityBO.setDeviceId(request.getDeviceId());
@@ -82,13 +84,17 @@ public class EventHistoryServer extends EventHistoryApiGrpc.EventHistoryApiImplB
                     .setResult(GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage()))
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 
     @Override
     public void getByRecordId(GrpcStringQuery request, StreamObserver<GrpcREventHistoryDTO> responseObserver) {
         try {
-            EventHistoryVO record = eventHistoryService.getByRecordId(request.getValue());
+            // record_id is globally unique but dc3_event_history is not tenant-whitelisted;
+            // the GrpcStringQuery carries no tenant_id, so bypass tenant filtering here.
+            EventHistoryVO record = TenantContextHolder.runIgnore(() -> eventHistoryService.getByRecordId(request.getValue()));
             GrpcREventHistoryDTO.Builder response = GrpcREventHistoryDTO.newBuilder();
 
             if (Objects.nonNull(record)) {
@@ -110,6 +116,7 @@ public class EventHistoryServer extends EventHistoryApiGrpc.EventHistoryApiImplB
 
     @Override
     public void listByPage(GrpcEventHistoryQuery request, StreamObserver<GrpcRPageEventHistoryDTO> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             EventHistoryQueryVO queryVO = new EventHistoryQueryVO();
             queryVO.setDeviceId(request.getDeviceId() != 0 ? request.getDeviceId() : null);
@@ -141,6 +148,8 @@ public class EventHistoryServer extends EventHistoryApiGrpc.EventHistoryApiImplB
                     .setResult(GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage()))
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/PointValueServer.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/PointValueServer.java
@@ -31,6 +31,7 @@ import io.github.pnoker.common.data.biz.PointValueService;
 import io.github.pnoker.common.data.entity.bo.PointCommandReadBO;
 import io.github.pnoker.common.data.entity.bo.PointCommandWriteBO;
 import io.github.pnoker.common.enums.ErrorCode;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,6 +59,7 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
 
     @Override
     public void getLastValue(GrpcPointValueQuery request, StreamObserver<GrpcRPointValueDTO> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             // latest() with a page query — simplified: query by device+point, return
             // first result
@@ -100,12 +102,15 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
                     .setResult(GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage()))
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 
     @Override
     public void listHistoryValues(GrpcPointValueHistoryQuery request,
                                   StreamObserver<GrpcRPointValueStringList> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             List<String> history = pointValueService.history(request.getTenantId(), request.getDeviceId(),
                     request.getPointId(), request.getCount());
@@ -125,11 +130,14 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
                     .setResult(GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage()))
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 
     @Override
     public void readCommand(GrpcPointValueCommandQuery request, StreamObserver<GrpcRBoolean> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             PointCommandReadBO entityBO = new PointCommandReadBO();
             entityBO.setDeviceId(request.getDeviceId());
@@ -149,11 +157,14 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
                     .setData(false)
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 
     @Override
     public void writeCommand(GrpcPointValueWriteCommand request, StreamObserver<GrpcRBoolean> responseObserver) {
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
             PointCommandWriteBO entityBO = new PointCommandWriteBO();
             entityBO.setDeviceId(request.getDeviceId());
@@ -174,6 +185,8 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
                     .setData(false)
                     .build());
             responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
     }
 

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/StatusHealthServer.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/StatusHealthServer.java
@@ -35,6 +35,7 @@ import io.github.pnoker.common.data.entity.model.EntityStateDO;
 import io.github.pnoker.common.data.entity.vo.dashboard.SystemHealthVO;
 import io.github.pnoker.common.enums.EntityStatusEnum;
 import io.github.pnoker.common.enums.EntityTypeEnum;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.github.pnoker.common.facade.api.DeviceFacade;
 import io.github.pnoker.common.facade.api.DriverFacade;
 import io.github.pnoker.common.facade.entity.bo.FacadeDeviceBO;
@@ -73,71 +74,96 @@ public class StatusHealthServer extends StatusHealthApiGrpc.StatusHealthApiImplB
 
     @Override
     public void deviceStatusesByIds(GrpcIdsStatusQuery request, StreamObserver<GrpcRStatusMap> responseObserver) {
-        List<FacadeDeviceBO> devices = deviceFacade.listByIds(request.getTenantId(), request.getIdsList());
-        Map<Long, String> statuses = new LinkedHashMap<>();
-        devices.forEach(device -> statuses.put(device.getId(), deviceStatus(request.getTenantId(), device.getId())));
-        responseObserver.onNext(GrpcRStatusMap.newBuilder().setResult(ok()).putAllData(statuses).build());
-        responseObserver.onCompleted();
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            List<FacadeDeviceBO> devices = deviceFacade.listByIds(request.getTenantId(), request.getIdsList());
+            Map<Long, String> statuses = new LinkedHashMap<>();
+            devices.forEach(device -> statuses.put(device.getId(), deviceStatus(request.getTenantId(), device.getId())));
+            responseObserver.onNext(GrpcRStatusMap.newBuilder().setResult(ok()).putAllData(statuses).build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
     public void deviceStatusesByProfileId(GrpcProfileStatusQuery request,
                                           StreamObserver<GrpcRStatusMap> responseObserver) {
-        List<FacadeDeviceBO> devices = deviceFacade.listByProfileId(request.getTenantId(), request.getProfileId());
-        Map<Long, String> statuses = new LinkedHashMap<>();
-        devices.forEach(device -> statuses.put(device.getId(), deviceStatus(request.getTenantId(), device.getId())));
-        responseObserver.onNext(GrpcRStatusMap.newBuilder().setResult(ok()).putAllData(statuses).build());
-        responseObserver.onCompleted();
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            List<FacadeDeviceBO> devices = deviceFacade.listByProfileId(request.getTenantId(), request.getProfileId());
+            Map<Long, String> statuses = new LinkedHashMap<>();
+            devices.forEach(device -> statuses.put(device.getId(), deviceStatus(request.getTenantId(), device.getId())));
+            responseObserver.onNext(GrpcRStatusMap.newBuilder().setResult(ok()).putAllData(statuses).build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
     public void driverStatusesByIds(GrpcIdsStatusQuery request, StreamObserver<GrpcRStatusMap> responseObserver) {
-        List<FacadeDriverBO> drivers = driverFacade.listByIds(request.getTenantId(), request.getIdsList());
-        Map<Long, String> statuses = new LinkedHashMap<>();
-        drivers.forEach(driver -> statuses.put(driver.getId(), driverStatus(request.getTenantId(), driver.getId())));
-        responseObserver.onNext(GrpcRStatusMap.newBuilder().setResult(ok()).putAllData(statuses).build());
-        responseObserver.onCompleted();
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            List<FacadeDriverBO> drivers = driverFacade.listByIds(request.getTenantId(), request.getIdsList());
+            Map<Long, String> statuses = new LinkedHashMap<>();
+            drivers.forEach(driver -> statuses.put(driver.getId(), driverStatus(request.getTenantId(), driver.getId())));
+            responseObserver.onNext(GrpcRStatusMap.newBuilder().setResult(ok()).putAllData(statuses).build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
     public void driverDeviceStatusSummary(GrpcDriverStatusQuery request,
                                           StreamObserver<GrpcRStringMap> responseObserver) {
-        FacadeDriverBO driver = driverFacade.getById(request.getTenantId(), request.getDriverId());
-        if (Objects.isNull(driver)) {
-            responseObserver.onNext(GrpcRStringMap.newBuilder().setResult(noResource()).build());
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            FacadeDriverBO driver = driverFacade.getById(request.getTenantId(), request.getDriverId());
+            if (Objects.isNull(driver)) {
+                responseObserver.onNext(GrpcRStringMap.newBuilder().setResult(noResource()).build());
+                responseObserver.onCompleted();
+                return;
+            }
+            List<FacadeDeviceBO> devices = deviceFacade.listByDriverId(request.getTenantId(), request.getDriverId());
+            long online = devices.stream()
+                    .filter(device -> Objects.equals(EntityStatusEnum.ONLINE.getCode(),
+                            deviceStatus(request.getTenantId(), device.getId())))
+                    .count();
+            FacadeDriverDeviceStatusSummaryBO summary = new FacadeDriverDeviceStatusSummaryBO(
+                    request.getDriverId(),
+                    devices.size(),
+                    (int) online,
+                    (int) Math.max(0, devices.size() - online));
+            responseObserver.onNext(GrpcRStringMap.newBuilder().setResult(ok()).putAllData(summary.toMap()).build());
             responseObserver.onCompleted();
-            return;
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<FacadeDeviceBO> devices = deviceFacade.listByDriverId(request.getTenantId(), request.getDriverId());
-        long online = devices.stream()
-                .filter(device -> Objects.equals(EntityStatusEnum.ONLINE.getCode(),
-                        deviceStatus(request.getTenantId(), device.getId())))
-                .count();
-        FacadeDriverDeviceStatusSummaryBO summary = new FacadeDriverDeviceStatusSummaryBO(
-                request.getDriverId(),
-                devices.size(),
-                (int) online,
-                (int) Math.max(0, devices.size() - online));
-        responseObserver.onNext(GrpcRStringMap.newBuilder().setResult(ok()).putAllData(summary.toMap()).build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void systemHealth(GrpcTenantHealthQuery request, StreamObserver<GrpcRSystemHealthDTO> responseObserver) {
-        SystemHealthVO health = systemHealthService.snapshot(request.getTenantId());
-        if (Objects.isNull(health)) {
-            responseObserver.onNext(GrpcRSystemHealthDTO.newBuilder().setResult(noResource()).build());
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            SystemHealthVO health = systemHealthService.snapshot(request.getTenantId());
+            if (Objects.isNull(health)) {
+                responseObserver.onNext(GrpcRSystemHealthDTO.newBuilder().setResult(noResource()).build());
+                responseObserver.onCompleted();
+                return;
+            }
+            GrpcSystemHealthDTO dto = GrpcSystemHealthDTO.newBuilder()
+                    .putAllCenter(nullToEmpty(health.getCenter()))
+                    .putAllInfra(nullToEmpty(health.getInfra()))
+                    .setDrivers(toGrpcSummary(health.getDrivers()))
+                    .setDevices(toGrpcSummary(health.getDevices()))
+                    .build();
+            responseObserver.onNext(GrpcRSystemHealthDTO.newBuilder().setResult(ok()).setData(dto).build());
             responseObserver.onCompleted();
-            return;
+        } finally {
+            TenantContextHolder.clear();
         }
-        GrpcSystemHealthDTO dto = GrpcSystemHealthDTO.newBuilder()
-                .putAllCenter(nullToEmpty(health.getCenter()))
-                .putAllInfra(nullToEmpty(health.getInfra()))
-                .setDrivers(toGrpcSummary(health.getDrivers()))
-                .setDevices(toGrpcSummary(health.getDevices()))
-                .build();
-        responseObserver.onNext(GrpcRSystemHealthDTO.newBuilder().setResult(ok()).setData(dto).build());
-        responseObserver.onCompleted();
     }
 
     private Map<String, String> nullToEmpty(Map<String, String> source) {

--- a/dc3-common/dc3-common-data/src/test/java/io/github/pnoker/common/data/biz/impl/DeviceAlarmServiceImplTest.java
+++ b/dc3-common/dc3-common-data/src/test/java/io/github/pnoker/common/data/biz/impl/DeviceAlarmServiceImplTest.java
@@ -92,27 +92,20 @@ class DeviceAlarmServiceImplTest {
     }
 
     @Test
-    void backfillsTenantIdViaFacadeWhenDtoMissesIt() {
+    void dropsAlarmWhenTenantIdIsMissing() {
+        // The fail-closed tenant-line interceptor forbids reverse-resolving the tenant from
+        // the device, so a tenant-less alarm is dropped rather than persisted as tenant_id=0.
         DeviceAlarmDTO dto = DeviceAlarmDTO.builder()
                 .deviceId(10L)
                 .driverId(3L)
                 .message("offline")
                 .build(); // tenantId missing
-        FacadeDeviceBO device = new FacadeDeviceBO();
-        device.setId(10L);
-        device.setTenantId(7L);
-        device.setDriverId(3L);
-        when(deviceFacade.getById(10L)).thenReturn(device);
 
         service.alarm(dto);
 
-        ArgumentCaptor<EntityAlarmDO> captor = ArgumentCaptor.forClass(EntityAlarmDO.class);
-        verify(entityAlarmManager).save(captor.capture());
-        // Tenant id is now backfilled both on the persisted row and on the DTO so the
-        // downstream rule trigger sees a valid tenant context.
-        assertThat(captor.getValue().getTenantId()).isEqualTo(7L);
-        assertThat(dto.getTenantId()).isEqualTo(7L);
-        verify(alarmRuleTriggerService).processDeviceAlarm(dto);
+        verifyNoInteractions(deviceFacade);
+        verify(entityAlarmManager, never()).save(any());
+        verifyNoInteractions(alarmRuleTriggerService);
     }
 
     @Test
@@ -126,7 +119,7 @@ class DeviceAlarmServiceImplTest {
         device.setId(10L);
         device.setTenantId(7L);
         device.setDriverId(99L);
-        when(deviceFacade.getById(10L)).thenReturn(device);
+        when(deviceFacade.getById(7L, 10L)).thenReturn(device);
 
         service.alarm(dto);
 
@@ -140,25 +133,10 @@ class DeviceAlarmServiceImplTest {
     void dropsAlarmWhenDeviceMetadataIsUnavailable() {
         DeviceAlarmDTO dto = DeviceAlarmDTO.builder()
                 .deviceId(10L)
+                .tenantId(7L)
                 .message("offline")
-                .build(); // missing tenantId + driverId
-        when(deviceFacade.getById(10L)).thenReturn(null);
-
-        service.alarm(dto);
-
-        // Without a tenant id we must not write to dc3_entity_alarm with tenant_id=0
-        // because the rule trigger then silently drops the event downstream.
-        verify(entityAlarmManager, never()).save(any());
-        verifyNoInteractions(alarmRuleTriggerService);
-    }
-
-    @Test
-    void dropsAlarmWhenFacadeReturnsDeviceWithoutTenantId() {
-        DeviceAlarmDTO dto = DeviceAlarmDTO.builder().deviceId(10L).message("x").build();
-        FacadeDeviceBO device = new FacadeDeviceBO();
-        device.setId(10L);
-        // tenantId left null
-        when(deviceFacade.getById(10L)).thenReturn(device);
+                .build(); // driverId missing, device not found
+        when(deviceFacade.getById(7L, 10L)).thenReturn(null);
 
         service.alarm(dto);
 

--- a/dc3-common/dc3-common-data/src/test/java/io/github/pnoker/common/data/biz/impl/DriverAlarmServiceImplTest.java
+++ b/dc3-common/dc3-common-data/src/test/java/io/github/pnoker/common/data/biz/impl/DriverAlarmServiceImplTest.java
@@ -21,8 +21,6 @@ import io.github.pnoker.common.data.biz.alarm.AlarmRuleTriggerService;
 import io.github.pnoker.common.data.dal.EntityAlarmManager;
 import io.github.pnoker.common.data.entity.model.EntityAlarmDO;
 import io.github.pnoker.common.entity.dto.DriverAlarmDTO;
-import io.github.pnoker.common.facade.api.DriverFacade;
-import io.github.pnoker.common.facade.entity.bo.FacadeDriverBO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -35,7 +33,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DriverAlarmServiceImplTest {
@@ -46,23 +43,20 @@ class DriverAlarmServiceImplTest {
     @Mock
     private AlarmRuleTriggerService alarmRuleTriggerService;
 
-    @Mock
-    private DriverFacade driverFacade;
-
     @InjectMocks
     private DriverAlarmServiceImpl service;
 
     @Test
     void dropsAlarmWhenDtoIsNull() {
         service.alarm(null);
-        verifyNoInteractions(entityAlarmManager, alarmRuleTriggerService, driverFacade);
+        verifyNoInteractions(entityAlarmManager, alarmRuleTriggerService);
     }
 
     @Test
     void dropsAlarmWhenDriverIdMissing() {
         DriverAlarmDTO dto = DriverAlarmDTO.builder().tenantId(7L).message("x").build();
         service.alarm(dto);
-        verifyNoInteractions(entityAlarmManager, alarmRuleTriggerService, driverFacade);
+        verifyNoInteractions(entityAlarmManager, alarmRuleTriggerService);
     }
 
     @Test
@@ -75,7 +69,6 @@ class DriverAlarmServiceImplTest {
 
         service.alarm(dto);
 
-        verifyNoInteractions(driverFacade);
         ArgumentCaptor<EntityAlarmDO> captor = ArgumentCaptor.forClass(EntityAlarmDO.class);
         verify(entityAlarmManager).save(captor.capture());
         assertThat(captor.getValue().getTenantId()).isEqualTo(7L);
@@ -83,42 +76,13 @@ class DriverAlarmServiceImplTest {
     }
 
     @Test
-    void backfillsTenantIdViaFacadeWhenDtoMissesIt() {
+    void dropsAlarmWhenTenantIdIsMissing() {
+        // The fail-closed tenant-line interceptor forbids reverse-resolving the tenant from
+        // the driver, so a tenant-less alarm is dropped rather than persisted as tenant_id=0.
         DriverAlarmDTO dto = DriverAlarmDTO.builder()
                 .driverId(3L)
                 .message("offline")
                 .build(); // tenantId missing
-        FacadeDriverBO driver = new FacadeDriverBO();
-        driver.setId(3L);
-        driver.setTenantId(7L);
-        when(driverFacade.getById(3L)).thenReturn(driver);
-
-        service.alarm(dto);
-
-        ArgumentCaptor<EntityAlarmDO> captor = ArgumentCaptor.forClass(EntityAlarmDO.class);
-        verify(entityAlarmManager).save(captor.capture());
-        assertThat(captor.getValue().getTenantId()).isEqualTo(7L);
-        assertThat(dto.getTenantId()).isEqualTo(7L);
-        verify(alarmRuleTriggerService).processDriverAlarm(dto);
-    }
-
-    @Test
-    void dropsAlarmWhenDriverMetadataIsUnavailable() {
-        DriverAlarmDTO dto = DriverAlarmDTO.builder().driverId(3L).message("offline").build();
-        when(driverFacade.getById(3L)).thenReturn(null);
-
-        service.alarm(dto);
-
-        verify(entityAlarmManager, never()).save(any());
-        verifyNoInteractions(alarmRuleTriggerService);
-    }
-
-    @Test
-    void dropsAlarmWhenFacadeReturnsDriverWithoutTenantId() {
-        DriverAlarmDTO dto = DriverAlarmDTO.builder().driverId(3L).message("x").build();
-        FacadeDriverBO driver = new FacadeDriverBO();
-        driver.setId(3L);
-        when(driverFacade.getById(3L)).thenReturn(driver);
 
         service.alarm(dto);
 

--- a/dc3-common/dc3-common-driver/src/main/java/io/github/pnoker/common/driver/grpc/client/DeviceClient.java
+++ b/dc3-common/dc3-common-driver/src/main/java/io/github/pnoker/common/driver/grpc/client/DeviceClient.java
@@ -109,7 +109,8 @@ public class DeviceClient {
      */
     public DeviceBO getById(Long id) {
         GrpcDeviceQuery.Builder query = GrpcDeviceQuery.newBuilder();
-        query.setDriverId(driverMetadata.getDriver().getId()).setDeviceId(id);
+        query.setTenantId(driverMetadata.getDriver().getTenantId())
+                .setDriverId(driverMetadata.getDriver().getId()).setDeviceId(id);
         GrpcRDeviceDTO rDeviceDTO = deviceApiBlockingStub.getById(query.build());
         if (!rDeviceDTO.getResult().getOk()) {
             log.error("Device doesn't exist: {}", id);

--- a/dc3-common/dc3-common-driver/src/main/java/io/github/pnoker/common/driver/grpc/client/DriverClient.java
+++ b/dc3-common/dc3-common-driver/src/main/java/io/github/pnoker/common/driver/grpc/client/DriverClient.java
@@ -137,7 +137,9 @@ public class DriverClient {
             throw new ServiceException("Failed to refresh driver metadata: invalid driver id");
         }
 
-        GrpcDriverQuery query = GrpcDriverQuery.newBuilder().setDriverId(driverId).build();
+        GrpcDriverQuery query = GrpcDriverQuery.newBuilder()
+                .setTenantId(driverMetadata.getDriver().getTenantId())
+                .setDriverId(driverId).build();
         GrpcRDriverRegisterDTO rDriverRegisterDTO = driverApiBlockingStub.getById(query);
         if (!rDriverRegisterDTO.getResult().getOk()) {
             throw new ServiceException(rDriverRegisterDTO.getResult().getMessage());

--- a/dc3-common/dc3-common-driver/src/main/java/io/github/pnoker/common/driver/grpc/client/PointClient.java
+++ b/dc3-common/dc3-common-driver/src/main/java/io/github/pnoker/common/driver/grpc/client/PointClient.java
@@ -84,7 +84,8 @@ public class PointClient {
      */
     public PointBO getById(Long id) {
         GrpcPointQuery.Builder query = GrpcPointQuery.newBuilder();
-        query.setDriverId(driverMetadata.getDriver().getId()).setPointId(id);
+        query.setTenantId(driverMetadata.getDriver().getTenantId())
+                .setDriverId(driverMetadata.getDriver().getId()).setPointId(id);
         GrpcRPointDTO rPointDTO = pointApiBlockingStub.getById(query.build());
         if (!rPointDTO.getResult().getOk()) {
             log.error("Point doesn't exist: {}", id);

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/CommandFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/CommandFacade.java
@@ -22,12 +22,10 @@ import io.github.pnoker.common.facade.entity.common.FacadePage;
 import io.github.pnoker.common.facade.entity.query.FacadeCommandQuery;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
- * Protocol-neutral command facade.
+ * Protocol-neutral command facade. Single-record and bulk lookups are tenant-scoped.
  *
  * @author pnoker
  * @version 2025.9.0
@@ -35,31 +33,20 @@ import java.util.Objects;
  */
 public interface CommandFacade {
 
-    private static boolean matchesTenant(Long tenantId, FacadeCommandBO command) {
-        return Objects.nonNull(command) && Objects.equals(tenantId, command.getTenantId());
-    }
+    /**
+     * Tenant-scoped single lookup. Returns {@code null} when the command is missing or
+     * belongs to another tenant.
+     */
+    FacadeCommandBO getById(Long tenantId, Long id);
 
-    FacadeCommandBO getById(Long id);
+    /**
+     * Tenant-scoped bulk lookup. Missing or cross-tenant commands are omitted.
+     */
+    List<FacadeCommandBO> listByIds(Long tenantId, Collection<Long> ids);
 
-    default FacadeCommandBO getById(Long tenantId, Long id) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadeCommandBO command = getById(id);
-        return matchesTenant(tenantId, command) ? command : null;
-    }
-
-    List<FacadeCommandBO> listByIds(Collection<Long> ids);
-
-    default List<FacadeCommandBO> listByIds(Long tenantId, Collection<Long> ids) {
-        if (Objects.isNull(tenantId) || Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return listByIds(ids).stream()
-                .filter(command -> matchesTenant(tenantId, command))
-                .toList();
-    }
-
+    /**
+     * @return a page of commands (never {@code null}; empty page when nothing matches).
+     */
     FacadePage<FacadeCommandBO> listByPage(FacadeCommandQuery query);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/DeviceFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/DeviceFacade.java
@@ -22,14 +22,12 @@ import io.github.pnoker.common.facade.entity.common.FacadePage;
 import io.github.pnoker.common.facade.entity.query.FacadeDeviceQuery;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Protocol-neutral device facade.
  * <p>
- * Mirrors the four RPCs on {@code api.center.manager.DeviceApi} but returns plain BO/Page
+ * Mirrors the RPCs on {@code api.center.manager.DeviceApi} but returns plain BO/Page
  * types so callers never have to touch gRPC or protobuf classes. Two implementations back
  * this interface:
  * <ul>
@@ -38,6 +36,9 @@ import java.util.Objects;
  * <li>{@code DeviceGrpcFacade} — gRPC call against Manager Center, selected when
  * {@code dc3.facade.mode=grpc} (distributed deployment, default).</li>
  * </ul>
+ * <p>
+ * Single-record and bulk lookups are tenant-scoped: the tenant id rides on the gRPC query
+ * (or the thread-local in local mode) so the manager center enforces tenant isolation.
  *
  * @author pnoker
  * @version 2025.9.0
@@ -45,48 +46,16 @@ import java.util.Objects;
  */
 public interface DeviceFacade {
 
-    private static boolean matchesTenant(Long tenantId, FacadeDeviceBO device) {
-        return Objects.nonNull(device) && Objects.equals(tenantId, device.getTenantId());
-    }
-
-    /**
-     * Query a single device by id.
-     *
-     * @return the device, or {@code null} when the device does not exist.
-     */
-    FacadeDeviceBO getById(Long id);
-
     /**
      * Tenant-scoped single lookup. Returns {@code null} when the device is missing or
      * belongs to another tenant.
      */
-    default FacadeDeviceBO getById(Long tenantId, Long id) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadeDeviceBO device = getById(id);
-        return matchesTenant(tenantId, device) ? device : null;
-    }
-
-    /**
-     * Bulk lookup. Avoids the N+1 cost of calling {@link #getById(Long)} in a loop.
-     *
-     * @return list of resolved devices (missing ids are simply omitted; never {@code
-     * null}).
-     */
-    List<FacadeDeviceBO> listByIds(Collection<Long> ids);
+    FacadeDeviceBO getById(Long tenantId, Long id);
 
     /**
      * Tenant-scoped bulk lookup. Missing or cross-tenant devices are omitted.
      */
-    default List<FacadeDeviceBO> listByIds(Long tenantId, Collection<Long> ids) {
-        if (Objects.isNull(tenantId) || Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return listByIds(ids).stream()
-                .filter(device -> matchesTenant(tenantId, device))
-                .toList();
-    }
+    List<FacadeDeviceBO> listByIds(Long tenantId, Collection<Long> ids);
 
     /**
      * Paginated query.
@@ -96,41 +65,13 @@ public interface DeviceFacade {
     FacadePage<FacadeDeviceBO> listByPage(FacadeDeviceQuery query);
 
     /**
-     * List devices attached to a given profile.
-     *
-     * @return an immutable list (never {@code null}; empty when nothing matches).
-     */
-    List<FacadeDeviceBO> listByProfileId(Long profileId);
-
-    /**
      * Tenant-scoped lookup by profile. Cross-tenant devices are omitted.
      */
-    default List<FacadeDeviceBO> listByProfileId(Long tenantId, Long profileId) {
-        if (Objects.isNull(tenantId)) {
-            return Collections.emptyList();
-        }
-        return listByProfileId(profileId).stream()
-                .filter(device -> matchesTenant(tenantId, device))
-                .toList();
-    }
-
-    /**
-     * List devices attached to a given driver.
-     *
-     * @return an immutable list (never {@code null}; empty when nothing matches).
-     */
-    List<FacadeDeviceBO> listByDriverId(Long driverId);
+    List<FacadeDeviceBO> listByProfileId(Long tenantId, Long profileId);
 
     /**
      * Tenant-scoped lookup by driver. Cross-tenant devices are omitted.
      */
-    default List<FacadeDeviceBO> listByDriverId(Long tenantId, Long driverId) {
-        if (Objects.isNull(tenantId)) {
-            return Collections.emptyList();
-        }
-        return listByDriverId(driverId).stream()
-                .filter(device -> matchesTenant(tenantId, device))
-                .toList();
-    }
+    List<FacadeDeviceBO> listByDriverId(Long tenantId, Long driverId);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/DriverFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/DriverFacade.java
@@ -22,15 +22,15 @@ import io.github.pnoker.common.facade.entity.common.FacadePage;
 import io.github.pnoker.common.facade.entity.query.FacadeDriverQuery;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Protocol-neutral driver facade.
  * <p>
- * Mirrors the three RPCs on {@code api.center.manager.DriverApi}. Implementation
- * selection follows the same {@code dc3.facade.mode} switch used by {@link DeviceFacade}.
+ * Mirrors the RPCs on {@code api.center.manager.DriverApi}. Single-record and bulk
+ * lookups are tenant-scoped: the tenant id is carried on the gRPC query so the manager
+ * center's tenant-line interceptor scopes the SQL, and the local implementation binds
+ * it on the thread. Callers must supply the tenant id explicitly.
  *
  * @author pnoker
  * @version 2025.9.0
@@ -38,46 +38,16 @@ import java.util.Objects;
  */
 public interface DriverFacade {
 
-    private static boolean matchesTenant(Long tenantId, FacadeDriverBO driver) {
-        return Objects.nonNull(driver) && Objects.equals(tenantId, driver.getTenantId());
-    }
-
-    /**
-     * @return the driver, or {@code null} when it does not exist.
-     */
-    FacadeDriverBO getById(Long id);
-
     /**
      * Tenant-scoped single lookup. Returns {@code null} when the driver is missing or
      * belongs to another tenant.
      */
-    default FacadeDriverBO getById(Long tenantId, Long id) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadeDriverBO driver = getById(id);
-        return matchesTenant(tenantId, driver) ? driver : null;
-    }
-
-    /**
-     * Bulk lookup. Avoids the N+1 cost of calling {@link #getById(Long)} in a loop.
-     *
-     * @return list of resolved drivers (missing ids are simply omitted; never {@code
-     * null}).
-     */
-    List<FacadeDriverBO> listByIds(Collection<Long> ids);
+    FacadeDriverBO getById(Long tenantId, Long id);
 
     /**
      * Tenant-scoped bulk lookup. Missing or cross-tenant drivers are omitted.
      */
-    default List<FacadeDriverBO> listByIds(Long tenantId, Collection<Long> ids) {
-        if (Objects.isNull(tenantId) || Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return listByIds(ids).stream()
-                .filter(driver -> matchesTenant(tenantId, driver))
-                .toList();
-    }
+    List<FacadeDriverBO> listByIds(Long tenantId, Collection<Long> ids);
 
     /**
      * @return a page of drivers (never {@code null}; empty page when nothing matches).
@@ -85,22 +55,9 @@ public interface DriverFacade {
     FacadePage<FacadeDriverBO> listByPage(FacadeDriverQuery query);
 
     /**
-     * Resolve the driver that owns a given device.
-     *
-     * @return the driver, or {@code null} when the device has no bound driver.
-     */
-    FacadeDriverBO getByDeviceId(Long deviceId);
-
-    /**
      * Tenant-scoped owner lookup. Returns {@code null} when the owning driver is missing
      * or belongs to another tenant.
      */
-    default FacadeDriverBO getByDeviceId(Long tenantId, Long deviceId) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadeDriverBO driver = getByDeviceId(deviceId);
-        return matchesTenant(tenantId, driver) ? driver : null;
-    }
+    FacadeDriverBO getByDeviceId(Long tenantId, Long deviceId);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/EventFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/EventFacade.java
@@ -22,12 +22,10 @@ import io.github.pnoker.common.facade.entity.common.FacadePage;
 import io.github.pnoker.common.facade.entity.query.FacadeEventQuery;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
- * Protocol-neutral event facade.
+ * Protocol-neutral event facade. Single-record and bulk lookups are tenant-scoped.
  *
  * @author pnoker
  * @version 2025.9.0
@@ -35,31 +33,20 @@ import java.util.Objects;
  */
 public interface EventFacade {
 
-    private static boolean matchesTenant(Long tenantId, FacadeEventBO event) {
-        return Objects.nonNull(event) && Objects.equals(tenantId, event.getTenantId());
-    }
+    /**
+     * Tenant-scoped single lookup. Returns {@code null} when the event is missing or
+     * belongs to another tenant.
+     */
+    FacadeEventBO getById(Long tenantId, Long id);
 
-    FacadeEventBO getById(Long id);
+    /**
+     * Tenant-scoped bulk lookup. Missing or cross-tenant events are omitted.
+     */
+    List<FacadeEventBO> listByIds(Long tenantId, Collection<Long> ids);
 
-    default FacadeEventBO getById(Long tenantId, Long id) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadeEventBO event = getById(id);
-        return matchesTenant(tenantId, event) ? event : null;
-    }
-
-    List<FacadeEventBO> listByIds(Collection<Long> ids);
-
-    default List<FacadeEventBO> listByIds(Long tenantId, Collection<Long> ids) {
-        if (Objects.isNull(tenantId) || Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return listByIds(ids).stream()
-                .filter(event -> matchesTenant(tenantId, event))
-                .toList();
-    }
-
+    /**
+     * @return a page of events (never {@code null}; empty page when nothing matches).
+     */
     FacadePage<FacadeEventBO> listByPage(FacadeEventQuery query);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/PointFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/PointFacade.java
@@ -22,13 +22,11 @@ import io.github.pnoker.common.facade.entity.common.FacadePage;
 import io.github.pnoker.common.facade.entity.query.FacadePointQuery;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
- * Protocol-neutral point facade. Mirrors the two RPCs on
- * {@code api.center.manager.PointApi}.
+ * Protocol-neutral point facade. Mirrors the RPCs on
+ * {@code api.center.manager.PointApi}. Single-record and bulk lookups are tenant-scoped.
  *
  * @author pnoker
  * @version 2025.9.0
@@ -36,45 +34,16 @@ import java.util.Objects;
  */
 public interface PointFacade {
 
-    private static boolean matchesTenant(Long tenantId, FacadePointBO point) {
-        return Objects.nonNull(point) && Objects.equals(tenantId, point.getTenantId());
-    }
-
-    /**
-     * @return the point, or {@code null} when it does not exist.
-     */
-    FacadePointBO getById(Long id);
-
     /**
      * Tenant-scoped single lookup. Returns {@code null} when the point is missing or
      * belongs to another tenant.
      */
-    default FacadePointBO getById(Long tenantId, Long id) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadePointBO point = getById(id);
-        return matchesTenant(tenantId, point) ? point : null;
-    }
-
-    /**
-     * Bulk lookup. Avoids the N+1 cost of calling {@link #getById(Long)} in a loop.
-     *
-     * @return list of resolved points (missing ids are simply omitted; never {@code null}).
-     */
-    List<FacadePointBO> listByIds(Collection<Long> ids);
+    FacadePointBO getById(Long tenantId, Long id);
 
     /**
      * Tenant-scoped bulk lookup. Missing or cross-tenant points are omitted.
      */
-    default List<FacadePointBO> listByIds(Long tenantId, Collection<Long> ids) {
-        if (Objects.isNull(tenantId) || Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return listByIds(ids).stream()
-                .filter(point -> matchesTenant(tenantId, point))
-                .toList();
-    }
+    List<FacadePointBO> listByIds(Long tenantId, Collection<Long> ids);
 
     /**
      * @return a page of points (never {@code null}; empty page when nothing matches).

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/ProfileFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/ProfileFacade.java
@@ -22,12 +22,11 @@ import io.github.pnoker.common.facade.entity.common.FacadePage;
 import io.github.pnoker.common.facade.entity.query.FacadeProfileQuery;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
- * Protocol-neutral profile/template facade.
+ * Protocol-neutral profile/template facade. Single-record and bulk lookups are
+ * tenant-scoped.
  *
  * @author pnoker
  * @version 2026.5.14
@@ -35,42 +34,25 @@ import java.util.Objects;
  */
 public interface ProfileFacade {
 
-    private static boolean matchesTenant(Long tenantId, FacadeProfileBO profile) {
-        return Objects.nonNull(profile) && Objects.equals(tenantId, profile.getTenantId());
-    }
+    /**
+     * Tenant-scoped single lookup. Returns {@code null} when the profile is missing or
+     * belongs to another tenant.
+     */
+    FacadeProfileBO getById(Long tenantId, Long id);
 
-    FacadeProfileBO getById(Long id);
+    /**
+     * Tenant-scoped bulk lookup. Missing or cross-tenant profiles are omitted.
+     */
+    List<FacadeProfileBO> listByIds(Long tenantId, Collection<Long> ids);
 
-    default FacadeProfileBO getById(Long tenantId, Long id) {
-        if (Objects.isNull(tenantId)) {
-            return null;
-        }
-        FacadeProfileBO profile = getById(id);
-        return matchesTenant(tenantId, profile) ? profile : null;
-    }
-
-    List<FacadeProfileBO> listByIds(Collection<Long> ids);
-
-    default List<FacadeProfileBO> listByIds(Long tenantId, Collection<Long> ids) {
-        if (Objects.isNull(tenantId) || Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return listByIds(ids).stream()
-                .filter(profile -> matchesTenant(tenantId, profile))
-                .toList();
-    }
-
+    /**
+     * @return a page of profiles (never {@code null}; empty page when nothing matches).
+     */
     FacadePage<FacadeProfileBO> listByPage(FacadeProfileQuery query);
 
-    List<FacadeProfileBO> listByDeviceId(Long deviceId);
-
-    default List<FacadeProfileBO> listByDeviceId(Long tenantId, Long deviceId) {
-        if (Objects.isNull(tenantId)) {
-            return Collections.emptyList();
-        }
-        return listByDeviceId(deviceId).stream()
-                .filter(profile -> matchesTenant(tenantId, profile))
-                .toList();
-    }
+    /**
+     * Tenant-scoped lookup by device. Cross-tenant profiles are omitted.
+     */
+    List<FacadeProfileBO> listByDeviceId(Long tenantId, Long deviceId);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/CommandGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/CommandGrpcFacade.java
@@ -62,8 +62,8 @@ public class CommandGrpcFacade implements CommandFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public FacadeCommandBO getById(Long id) {
-        GrpcCommandQuery request = GrpcCommandQuery.newBuilder().setCommandId(id).build();
+    public FacadeCommandBO getById(Long tenantId, Long id) {
+        GrpcCommandQuery request = GrpcCommandQuery.newBuilder().setCommandId(id).setTenantId(tenantId).build();
         GrpcRCommandDTO response = grpcFacadeSupport.call("CommandFacade.getById", commandApiBlockingStub,
                 stub -> stub.getById(request));
         if (!response.getResult().getOk()) {
@@ -74,7 +74,7 @@ public class CommandGrpcFacade implements CommandFacade {
     }
 
     @Override
-    public List<FacadeCommandBO> listByIds(Collection<Long> ids) {
+    public List<FacadeCommandBO> listByIds(Long tenantId, Collection<Long> ids) {
         if (Objects.isNull(ids) || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -83,7 +83,7 @@ public class CommandGrpcFacade implements CommandFacade {
             return Collections.emptyList();
         }
 
-        GrpcCommandIdsQuery request = GrpcCommandIdsQuery.newBuilder().addAllCommandIds(commandIds).build();
+        GrpcCommandIdsQuery request = GrpcCommandIdsQuery.newBuilder().addAllCommandIds(commandIds).setTenantId(tenantId).build();
         GrpcRCommandListDTO response = grpcFacadeSupport.call("CommandFacade.listByIds", commandApiBlockingStub,
                 stub -> stub.listByIds(request));
         if (!response.getResult().getOk()) {

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/DeviceGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/DeviceGrpcFacade.java
@@ -67,8 +67,8 @@ public class DeviceGrpcFacade implements DeviceFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public FacadeDeviceBO getById(Long id) {
-        GrpcDeviceQuery request = GrpcDeviceQuery.newBuilder().setDeviceId(id).build();
+    public FacadeDeviceBO getById(Long tenantId, Long id) {
+        GrpcDeviceQuery request = GrpcDeviceQuery.newBuilder().setDeviceId(id).setTenantId(tenantId).build();
         GrpcRDeviceDTO response = grpcFacadeSupport.call("DeviceFacade.getById", deviceApiBlockingStub,
                 stub -> stub.getByDeviceId(request));
         if (!response.getResult().getOk()) {
@@ -79,7 +79,7 @@ public class DeviceGrpcFacade implements DeviceFacade {
     }
 
     @Override
-    public List<FacadeDeviceBO> listByIds(Collection<Long> ids) {
+    public List<FacadeDeviceBO> listByIds(Long tenantId, Collection<Long> ids) {
         if (Objects.isNull(ids) || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -88,7 +88,7 @@ public class DeviceGrpcFacade implements DeviceFacade {
             return Collections.emptyList();
         }
 
-        GrpcDeviceIdsQuery request = GrpcDeviceIdsQuery.newBuilder().addAllDeviceIds(deviceIds).build();
+        GrpcDeviceIdsQuery request = GrpcDeviceIdsQuery.newBuilder().addAllDeviceIds(deviceIds).setTenantId(tenantId).build();
         GrpcRDeviceListDTO response = grpcFacadeSupport.call("DeviceFacade.listByIds", deviceApiBlockingStub,
                 stub -> stub.listByDeviceIds(request));
         if (!response.getResult().getOk()) {
@@ -116,8 +116,8 @@ public class DeviceGrpcFacade implements DeviceFacade {
     }
 
     @Override
-    public List<FacadeDeviceBO> listByProfileId(Long profileId) {
-        GrpcProfileQuery request = GrpcProfileQuery.newBuilder().setProfileId(profileId).build();
+    public List<FacadeDeviceBO> listByProfileId(Long tenantId, Long profileId) {
+        GrpcProfileQuery request = GrpcProfileQuery.newBuilder().setProfileId(profileId).setTenantId(tenantId).build();
         GrpcRDeviceListDTO response = grpcFacadeSupport.call("DeviceFacade.listByProfileId", deviceApiBlockingStub,
                 stub -> stub.listByProfileId(request));
         if (!response.getResult().getOk()) {
@@ -128,8 +128,8 @@ public class DeviceGrpcFacade implements DeviceFacade {
     }
 
     @Override
-    public List<FacadeDeviceBO> listByDriverId(Long driverId) {
-        GrpcDriverQuery request = GrpcDriverQuery.newBuilder().setDriverId(driverId).build();
+    public List<FacadeDeviceBO> listByDriverId(Long tenantId, Long driverId) {
+        GrpcDriverQuery request = GrpcDriverQuery.newBuilder().setDriverId(driverId).setTenantId(tenantId).build();
         GrpcRDeviceListDTO response = grpcFacadeSupport.call("DeviceFacade.listByDriverId", deviceApiBlockingStub,
                 stub -> stub.listByDriverId(request));
         if (!response.getResult().getOk()) {

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/DriverGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/DriverGrpcFacade.java
@@ -63,8 +63,8 @@ public class DriverGrpcFacade implements DriverFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public FacadeDriverBO getById(Long id) {
-        GrpcDriverQuery request = GrpcDriverQuery.newBuilder().setDriverId(id).build();
+    public FacadeDriverBO getById(Long tenantId, Long id) {
+        GrpcDriverQuery request = GrpcDriverQuery.newBuilder().setDriverId(id).setTenantId(tenantId).build();
         GrpcRDriverDTO response = grpcFacadeSupport.call("DriverFacade.getById", driverApiBlockingStub,
                 stub -> stub.getByDriverId(request));
         if (!response.getResult().getOk()) {
@@ -75,7 +75,7 @@ public class DriverGrpcFacade implements DriverFacade {
     }
 
     @Override
-    public List<FacadeDriverBO> listByIds(Collection<Long> ids) {
+    public List<FacadeDriverBO> listByIds(Long tenantId, Collection<Long> ids) {
         if (Objects.isNull(ids) || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -84,7 +84,7 @@ public class DriverGrpcFacade implements DriverFacade {
             return Collections.emptyList();
         }
 
-        GrpcDriverIdsQuery request = GrpcDriverIdsQuery.newBuilder().addAllDriverIds(driverIds).build();
+        GrpcDriverIdsQuery request = GrpcDriverIdsQuery.newBuilder().addAllDriverIds(driverIds).setTenantId(tenantId).build();
         GrpcRDriverListDTO response = grpcFacadeSupport.call("DriverFacade.listByIds", driverApiBlockingStub,
                 stub -> stub.listByDriverIds(request));
         if (!response.getResult().getOk()) {
@@ -112,8 +112,8 @@ public class DriverGrpcFacade implements DriverFacade {
     }
 
     @Override
-    public FacadeDriverBO getByDeviceId(Long deviceId) {
-        GrpcDeviceQuery request = GrpcDeviceQuery.newBuilder().setDeviceId(deviceId).build();
+    public FacadeDriverBO getByDeviceId(Long tenantId, Long deviceId) {
+        GrpcDeviceQuery request = GrpcDeviceQuery.newBuilder().setDeviceId(deviceId).setTenantId(tenantId).build();
         GrpcRDriverDTO response = grpcFacadeSupport.call("DriverFacade.getByDeviceId", driverApiBlockingStub,
                 stub -> stub.getByDeviceId(request));
         if (!response.getResult().getOk()) {

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/EventGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/EventGrpcFacade.java
@@ -62,8 +62,8 @@ public class EventGrpcFacade implements EventFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public FacadeEventBO getById(Long id) {
-        GrpcEventQuery request = GrpcEventQuery.newBuilder().setEventId(id).build();
+    public FacadeEventBO getById(Long tenantId, Long id) {
+        GrpcEventQuery request = GrpcEventQuery.newBuilder().setEventId(id).setTenantId(tenantId).build();
         GrpcREventDTO response = grpcFacadeSupport.call("EventFacade.getById", eventApiBlockingStub,
                 stub -> stub.getById(request));
         if (!response.getResult().getOk()) {
@@ -74,7 +74,7 @@ public class EventGrpcFacade implements EventFacade {
     }
 
     @Override
-    public List<FacadeEventBO> listByIds(Collection<Long> ids) {
+    public List<FacadeEventBO> listByIds(Long tenantId, Collection<Long> ids) {
         if (Objects.isNull(ids) || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -83,7 +83,7 @@ public class EventGrpcFacade implements EventFacade {
             return Collections.emptyList();
         }
 
-        GrpcEventIdsQuery request = GrpcEventIdsQuery.newBuilder().addAllEventIds(eventIds).build();
+        GrpcEventIdsQuery request = GrpcEventIdsQuery.newBuilder().addAllEventIds(eventIds).setTenantId(tenantId).build();
         GrpcREventListDTO response = grpcFacadeSupport.call("EventFacade.listByIds", eventApiBlockingStub,
                 stub -> stub.listByIds(request));
         if (!response.getResult().getOk()) {

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/PointGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/PointGrpcFacade.java
@@ -62,8 +62,8 @@ public class PointGrpcFacade implements PointFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public FacadePointBO getById(Long id) {
-        GrpcPointQuery request = GrpcPointQuery.newBuilder().setPointId(id).build();
+    public FacadePointBO getById(Long tenantId, Long id) {
+        GrpcPointQuery request = GrpcPointQuery.newBuilder().setPointId(id).setTenantId(tenantId).build();
         GrpcRPointDTO response = grpcFacadeSupport.call("PointFacade.getById", pointApiBlockingStub,
                 stub -> stub.getById(request));
         if (!response.getResult().getOk()) {
@@ -74,7 +74,7 @@ public class PointGrpcFacade implements PointFacade {
     }
 
     @Override
-    public List<FacadePointBO> listByIds(Collection<Long> ids) {
+    public List<FacadePointBO> listByIds(Long tenantId, Collection<Long> ids) {
         if (Objects.isNull(ids) || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -83,7 +83,7 @@ public class PointGrpcFacade implements PointFacade {
             return Collections.emptyList();
         }
 
-        GrpcPointIdsQuery request = GrpcPointIdsQuery.newBuilder().addAllPointIds(pointIds).build();
+        GrpcPointIdsQuery request = GrpcPointIdsQuery.newBuilder().addAllPointIds(pointIds).setTenantId(tenantId).build();
         GrpcRPointListDTO response = grpcFacadeSupport.call("PointFacade.listByIds", pointApiBlockingStub,
                 stub -> stub.listByIds(request));
         if (!response.getResult().getOk()) {

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/ProfileGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/ProfileGrpcFacade.java
@@ -61,8 +61,8 @@ public class ProfileGrpcFacade implements ProfileFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public FacadeProfileBO getById(Long id) {
-        GrpcProfileQuery request = GrpcProfileQuery.newBuilder().setProfileId(id).build();
+    public FacadeProfileBO getById(Long tenantId, Long id) {
+        GrpcProfileQuery request = GrpcProfileQuery.newBuilder().setProfileId(id).setTenantId(tenantId).build();
         GrpcRProfileDTO response = grpcFacadeSupport.call("ProfileFacade.getById", profileApiBlockingStub,
                 stub -> stub.getByProfileId(request));
         if (!response.getResult().getOk()) {
@@ -73,7 +73,7 @@ public class ProfileGrpcFacade implements ProfileFacade {
     }
 
     @Override
-    public List<FacadeProfileBO> listByIds(Collection<Long> ids) {
+    public List<FacadeProfileBO> listByIds(Long tenantId, Collection<Long> ids) {
         if (Objects.isNull(ids) || ids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -82,7 +82,7 @@ public class ProfileGrpcFacade implements ProfileFacade {
             return Collections.emptyList();
         }
 
-        GrpcProfileIdsQuery request = GrpcProfileIdsQuery.newBuilder().addAllProfileIds(profileIds).build();
+        GrpcProfileIdsQuery request = GrpcProfileIdsQuery.newBuilder().addAllProfileIds(profileIds).setTenantId(tenantId).build();
         GrpcRProfileListDTO response = grpcFacadeSupport.call("ProfileFacade.listByIds", profileApiBlockingStub,
                 stub -> stub.listByProfileIds(request));
         if (!response.getResult().getOk()) {
@@ -109,8 +109,8 @@ public class ProfileGrpcFacade implements ProfileFacade {
     }
 
     @Override
-    public List<FacadeProfileBO> listByDeviceId(Long deviceId) {
-        GrpcDeviceQuery request = GrpcDeviceQuery.newBuilder().setDeviceId(deviceId).build();
+    public List<FacadeProfileBO> listByDeviceId(Long tenantId, Long deviceId) {
+        GrpcDeviceQuery request = GrpcDeviceQuery.newBuilder().setDeviceId(deviceId).setTenantId(tenantId).build();
         GrpcRProfileListDTO response = grpcFacadeSupport.call("ProfileFacade.listByDeviceId", profileApiBlockingStub,
                 stub -> stub.listByDeviceId(request));
         if (!response.getResult().getOk()) {

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/CommandLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/CommandLocalFacade.java
@@ -26,6 +26,7 @@ import io.github.pnoker.common.facade.local.builder.FacadeCommandBuilder;
 import io.github.pnoker.common.manager.entity.bo.CommandBO;
 import io.github.pnoker.common.manager.entity.query.CommandQuery;
 import io.github.pnoker.common.manager.service.CommandService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,33 +54,48 @@ public class CommandLocalFacade implements CommandFacade {
     private final FacadeCommandBuilder facadeCommandBuilder;
 
     @Override
-    public FacadeCommandBO getById(Long id) {
-        CommandBO managerBO = commandService.getById(id);
-        return Objects.isNull(managerBO) ? null : facadeCommandBuilder.toFacadeBO(managerBO);
+    public FacadeCommandBO getById(Long tenantId, Long id) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            CommandBO managerBO = commandService.getById(id);
+            return Objects.isNull(managerBO) ? null : facadeCommandBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeCommandBO> listByIds(Collection<Long> ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeCommandBO> listByIds(Long tenantId, Collection<Long> ids) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            if (Objects.isNull(ids) || ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<CommandBO> list = commandService.listByIds(new HashSet<>(ids));
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeCommandBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<CommandBO> list = commandService.listByIds(new HashSet<>(ids));
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return list.stream().map(facadeCommandBuilder::toFacadeBO).toList();
     }
 
     @Override
     public FacadePage<FacadeCommandBO> listByPage(FacadeCommandQuery query) {
-        CommandQuery managerQuery = facadeCommandBuilder.toManagerQuery(query);
-        Page<CommandBO> page = commandService.list(managerQuery);
-        if (Objects.isNull(page)) {
-            return FacadePage.empty();
-        }
+        TenantContextHolder.setTenantId(query.getTenantId());
+        try {
+            CommandQuery managerQuery = facadeCommandBuilder.toManagerQuery(query);
+            Page<CommandBO> page = commandService.list(managerQuery);
+            if (Objects.isNull(page)) {
+                return FacadePage.empty();
+            }
 
-        List<FacadeCommandBO> records = page.getRecords().stream().map(facadeCommandBuilder::toFacadeBO).toList();
-        return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+            List<FacadeCommandBO> records = page.getRecords().stream().map(facadeCommandBuilder::toFacadeBO).toList();
+            return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/DeviceLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/DeviceLocalFacade.java
@@ -26,6 +26,7 @@ import io.github.pnoker.common.facade.local.builder.FacadeDeviceBuilder;
 import io.github.pnoker.common.manager.entity.bo.DeviceBO;
 import io.github.pnoker.common.manager.entity.query.DeviceQuery;
 import io.github.pnoker.common.manager.service.DeviceService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -56,51 +57,76 @@ public class DeviceLocalFacade implements DeviceFacade {
     private final FacadeDeviceBuilder facadeDeviceBuilder;
 
     @Override
-    public FacadeDeviceBO getById(Long id) {
-        DeviceBO managerBO = deviceService.getById(id);
-        return Objects.isNull(managerBO) ? null : facadeDeviceBuilder.toFacadeBO(managerBO);
+    public FacadeDeviceBO getById(Long tenantId, Long id) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            DeviceBO managerBO = deviceService.getById(id);
+            return Objects.isNull(managerBO) ? null : facadeDeviceBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeDeviceBO> listByIds(Collection<Long> ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeDeviceBO> listByIds(Long tenantId, Collection<Long> ids) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            if (Objects.isNull(ids) || ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<DeviceBO> list = deviceService.listByIds(new ArrayList<>(ids));
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeDeviceBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<DeviceBO> list = deviceService.listByIds(new ArrayList<>(ids));
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return list.stream().map(facadeDeviceBuilder::toFacadeBO).toList();
     }
 
     @Override
     public FacadePage<FacadeDeviceBO> listByPage(FacadeDeviceQuery query) {
-        DeviceQuery managerQuery = facadeDeviceBuilder.toManagerQuery(query);
-        Page<DeviceBO> page = deviceService.list(managerQuery);
-        if (Objects.isNull(page)) {
-            return FacadePage.empty();
-        }
+        TenantContextHolder.setTenantId(query.getTenantId());
+        try {
+            DeviceQuery managerQuery = facadeDeviceBuilder.toManagerQuery(query);
+            Page<DeviceBO> page = deviceService.list(managerQuery);
+            if (Objects.isNull(page)) {
+                return FacadePage.empty();
+            }
 
-        List<FacadeDeviceBO> records = page.getRecords().stream().map(facadeDeviceBuilder::toFacadeBO).toList();
-        return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+            List<FacadeDeviceBO> records = page.getRecords().stream().map(facadeDeviceBuilder::toFacadeBO).toList();
+            return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeDeviceBO> listByProfileId(Long profileId) {
-        List<DeviceBO> list = deviceService.listByProfileId(profileId, null);
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeDeviceBO> listByProfileId(Long tenantId, Long profileId) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            List<DeviceBO> list = deviceService.listByProfileId(profileId, null);
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeDeviceBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        return list.stream().map(facadeDeviceBuilder::toFacadeBO).toList();
     }
 
     @Override
-    public List<FacadeDeviceBO> listByDriverId(Long driverId) {
-        List<DeviceBO> list = deviceService.listByDriverId(driverId, null);
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeDeviceBO> listByDriverId(Long tenantId, Long driverId) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            List<DeviceBO> list = deviceService.listByDriverId(driverId, null);
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeDeviceBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        return list.stream().map(facadeDeviceBuilder::toFacadeBO).toList();
     }
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/DriverLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/DriverLocalFacade.java
@@ -26,6 +26,7 @@ import io.github.pnoker.common.facade.local.builder.FacadeDriverBuilder;
 import io.github.pnoker.common.manager.entity.bo.DriverBO;
 import io.github.pnoker.common.manager.entity.query.DriverQuery;
 import io.github.pnoker.common.manager.service.DriverService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,39 +54,59 @@ public class DriverLocalFacade implements DriverFacade {
     private final FacadeDriverBuilder facadeDriverBuilder;
 
     @Override
-    public FacadeDriverBO getById(Long id) {
-        DriverBO managerBO = driverService.getById(id);
-        return Objects.isNull(managerBO) ? null : facadeDriverBuilder.toFacadeBO(managerBO);
+    public FacadeDriverBO getById(Long tenantId, Long id) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            DriverBO managerBO = driverService.getById(id);
+            return Objects.isNull(managerBO) ? null : facadeDriverBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeDriverBO> listByIds(Collection<Long> ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeDriverBO> listByIds(Long tenantId, Collection<Long> ids) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            if (Objects.isNull(ids) || ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<DriverBO> list = driverService.listByIds(new HashSet<>(ids));
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeDriverBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<DriverBO> list = driverService.listByIds(new HashSet<>(ids));
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return list.stream().map(facadeDriverBuilder::toFacadeBO).toList();
     }
 
     @Override
     public FacadePage<FacadeDriverBO> listByPage(FacadeDriverQuery query) {
-        DriverQuery managerQuery = facadeDriverBuilder.toManagerQuery(query);
-        Page<DriverBO> page = driverService.list(managerQuery);
-        if (Objects.isNull(page)) {
-            return FacadePage.empty();
-        }
+        TenantContextHolder.setTenantId(query.getTenantId());
+        try {
+            DriverQuery managerQuery = facadeDriverBuilder.toManagerQuery(query);
+            Page<DriverBO> page = driverService.list(managerQuery);
+            if (Objects.isNull(page)) {
+                return FacadePage.empty();
+            }
 
-        List<FacadeDriverBO> records = page.getRecords().stream().map(facadeDriverBuilder::toFacadeBO).toList();
-        return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+            List<FacadeDriverBO> records = page.getRecords().stream().map(facadeDriverBuilder::toFacadeBO).toList();
+            return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public FacadeDriverBO getByDeviceId(Long deviceId) {
-        DriverBO managerBO = driverService.getByDeviceId(deviceId, null);
-        return Objects.isNull(managerBO) ? null : facadeDriverBuilder.toFacadeBO(managerBO);
+    public FacadeDriverBO getByDeviceId(Long tenantId, Long deviceId) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            DriverBO managerBO = driverService.getByDeviceId(deviceId, null);
+            return Objects.isNull(managerBO) ? null : facadeDriverBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/EventLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/EventLocalFacade.java
@@ -26,6 +26,7 @@ import io.github.pnoker.common.facade.local.builder.FacadeEventBuilder;
 import io.github.pnoker.common.manager.entity.bo.EventBO;
 import io.github.pnoker.common.manager.entity.query.EventQuery;
 import io.github.pnoker.common.manager.service.EventService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,33 +54,48 @@ public class EventLocalFacade implements EventFacade {
     private final FacadeEventBuilder facadeEventBuilder;
 
     @Override
-    public FacadeEventBO getById(Long id) {
-        EventBO managerBO = eventService.getById(id);
-        return Objects.isNull(managerBO) ? null : facadeEventBuilder.toFacadeBO(managerBO);
+    public FacadeEventBO getById(Long tenantId, Long id) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            EventBO managerBO = eventService.getById(id);
+            return Objects.isNull(managerBO) ? null : facadeEventBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeEventBO> listByIds(Collection<Long> ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeEventBO> listByIds(Long tenantId, Collection<Long> ids) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            if (Objects.isNull(ids) || ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<EventBO> list = eventService.listByIds(new HashSet<>(ids));
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeEventBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<EventBO> list = eventService.listByIds(new HashSet<>(ids));
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return list.stream().map(facadeEventBuilder::toFacadeBO).toList();
     }
 
     @Override
     public FacadePage<FacadeEventBO> listByPage(FacadeEventQuery query) {
-        EventQuery managerQuery = facadeEventBuilder.toManagerQuery(query);
-        Page<EventBO> page = eventService.list(managerQuery);
-        if (Objects.isNull(page)) {
-            return FacadePage.empty();
-        }
+        TenantContextHolder.setTenantId(query.getTenantId());
+        try {
+            EventQuery managerQuery = facadeEventBuilder.toManagerQuery(query);
+            Page<EventBO> page = eventService.list(managerQuery);
+            if (Objects.isNull(page)) {
+                return FacadePage.empty();
+            }
 
-        List<FacadeEventBO> records = page.getRecords().stream().map(facadeEventBuilder::toFacadeBO).toList();
-        return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+            List<FacadeEventBO> records = page.getRecords().stream().map(facadeEventBuilder::toFacadeBO).toList();
+            return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/PointLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/PointLocalFacade.java
@@ -26,6 +26,7 @@ import io.github.pnoker.common.facade.local.builder.FacadePointBuilder;
 import io.github.pnoker.common.manager.entity.bo.PointBO;
 import io.github.pnoker.common.manager.entity.query.PointQuery;
 import io.github.pnoker.common.manager.service.PointService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,33 +54,48 @@ public class PointLocalFacade implements PointFacade {
     private final FacadePointBuilder facadePointBuilder;
 
     @Override
-    public FacadePointBO getById(Long id) {
-        PointBO managerBO = pointService.getById(id);
-        return Objects.isNull(managerBO) ? null : facadePointBuilder.toFacadeBO(managerBO);
+    public FacadePointBO getById(Long tenantId, Long id) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            PointBO managerBO = pointService.getById(id);
+            return Objects.isNull(managerBO) ? null : facadePointBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadePointBO> listByIds(Collection<Long> ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadePointBO> listByIds(Long tenantId, Collection<Long> ids) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            if (Objects.isNull(ids) || ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<PointBO> list = pointService.listByIds(new HashSet<>(ids));
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadePointBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<PointBO> list = pointService.listByIds(new HashSet<>(ids));
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return list.stream().map(facadePointBuilder::toFacadeBO).toList();
     }
 
     @Override
     public FacadePage<FacadePointBO> listByPage(FacadePointQuery query) {
-        PointQuery managerQuery = facadePointBuilder.toManagerQuery(query);
-        Page<PointBO> page = pointService.list(managerQuery);
-        if (Objects.isNull(page)) {
-            return FacadePage.empty();
-        }
+        TenantContextHolder.setTenantId(query.getTenantId());
+        try {
+            PointQuery managerQuery = facadePointBuilder.toManagerQuery(query);
+            Page<PointBO> page = pointService.list(managerQuery);
+            if (Objects.isNull(page)) {
+                return FacadePage.empty();
+            }
 
-        List<FacadePointBO> records = page.getRecords().stream().map(facadePointBuilder::toFacadeBO).toList();
-        return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+            List<FacadePointBO> records = page.getRecords().stream().map(facadePointBuilder::toFacadeBO).toList();
+            return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/ProfileLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-manager/src/main/java/io/github/pnoker/common/facade/local/ProfileLocalFacade.java
@@ -26,6 +26,7 @@ import io.github.pnoker.common.facade.local.builder.FacadeProfileBuilder;
 import io.github.pnoker.common.manager.entity.bo.ProfileBO;
 import io.github.pnoker.common.manager.entity.query.ProfileQuery;
 import io.github.pnoker.common.manager.service.ProfileService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,42 +54,62 @@ public class ProfileLocalFacade implements ProfileFacade {
     private final FacadeProfileBuilder facadeProfileBuilder;
 
     @Override
-    public FacadeProfileBO getById(Long id) {
-        ProfileBO managerBO = profileService.getById(id);
-        return Objects.isNull(managerBO) ? null : facadeProfileBuilder.toFacadeBO(managerBO);
+    public FacadeProfileBO getById(Long tenantId, Long id) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            ProfileBO managerBO = profileService.getById(id);
+            return Objects.isNull(managerBO) ? null : facadeProfileBuilder.toFacadeBO(managerBO);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeProfileBO> listByIds(Collection<Long> ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeProfileBO> listByIds(Long tenantId, Collection<Long> ids) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            if (Objects.isNull(ids) || ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<ProfileBO> list = profileService.listByIds(new HashSet<>(ids));
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeProfileBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        List<ProfileBO> list = profileService.listByIds(new HashSet<>(ids));
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return list.stream().map(facadeProfileBuilder::toFacadeBO).toList();
     }
 
     @Override
     public FacadePage<FacadeProfileBO> listByPage(FacadeProfileQuery query) {
-        ProfileQuery managerQuery = facadeProfileBuilder.toManagerQuery(query);
-        Page<ProfileBO> page = profileService.list(managerQuery);
-        if (Objects.isNull(page)) {
-            return FacadePage.empty();
-        }
+        TenantContextHolder.setTenantId(query.getTenantId());
+        try {
+            ProfileQuery managerQuery = facadeProfileBuilder.toManagerQuery(query);
+            Page<ProfileBO> page = profileService.list(managerQuery);
+            if (Objects.isNull(page)) {
+                return FacadePage.empty();
+            }
 
-        List<FacadeProfileBO> records = page.getRecords().stream().map(facadeProfileBuilder::toFacadeBO).toList();
-        return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+            List<FacadeProfileBO> records = page.getRecords().stream().map(facadeProfileBuilder::toFacadeBO).toList();
+            return new FacadePage<>(page.getCurrent(), page.getSize(), page.getTotal(), page.getPages(), records);
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
-    public List<FacadeProfileBO> listByDeviceId(Long deviceId) {
-        List<ProfileBO> list = profileService.listByDeviceId(deviceId);
-        if (Objects.isNull(list) || list.isEmpty()) {
-            return Collections.emptyList();
+    public List<FacadeProfileBO> listByDeviceId(Long tenantId, Long deviceId) {
+        TenantContextHolder.setTenantId(tenantId);
+        try {
+            List<ProfileBO> list = profileService.listByDeviceId(deviceId);
+            if (Objects.isNull(list) || list.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return list.stream().map(facadeProfileBuilder::toFacadeBO).toList();
+        } finally {
+            TenantContextHolder.clear();
         }
-        return list.stream().map(facadeProfileBuilder::toFacadeBO).toList();
     }
 
 }

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/driver/DriverDeviceServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/driver/DriverDeviceServer.java
@@ -50,6 +50,7 @@ import io.github.pnoker.common.manager.service.EventAttributeConfigService;
 import io.github.pnoker.common.manager.service.PointAttributeConfigService;
 import io.github.pnoker.common.manager.service.PointService;
 import io.github.pnoker.common.optional.CollectionOptional;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -96,60 +97,70 @@ public class DriverDeviceServer extends DeviceApiGrpc.DeviceApiImplBase {
 
     @Override
     public void listByPage(GrpcPageDeviceQuery request, StreamObserver<GrpcRPageDeviceDTO> responseObserver) {
-        GrpcRPageDeviceDTO.Builder builder = GrpcRPageDeviceDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPageDeviceDTO.Builder builder = GrpcRPageDeviceDTO.newBuilder();
+            GrpcR result;
 
-        DeviceQuery query = grpcDeviceBuilder.buildQueryByGrpcQuery(request);
+            DeviceQuery query = grpcDeviceBuilder.buildQueryByGrpcQuery(request);
 
-        Page<DeviceBO> entityPage = driverInTenant(query.getTenantId(), query.getDriverId())
-                ? deviceService.list(query) : null;
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<DeviceBO> entityPage = driverInTenant(query.getTenantId(), query.getDriverId())
+                    ? deviceService.list(query) : null;
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPageDeviceDTO.Builder pageBuilder = GrpcPageDeviceDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pageBuilder.setPage(page);
+                GrpcPageDeviceDTO.Builder pageBuilder = GrpcPageDeviceDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pageBuilder.setPage(page);
 
-            List<GrpcRDeviceAttachDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(entityBO -> getDeviceAttachDTO(entityBO).build())
-                    .toList();
-            pageBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcRDeviceAttachDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(entityBO -> getDeviceAttachDTO(entityBO).build())
+                        .toList();
+                pageBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pageBuilder);
+                builder.setData(pageBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getById(GrpcDeviceQuery request, StreamObserver<GrpcRDeviceDTO> responseObserver) {
-        GrpcRDeviceDTO.Builder builder = GrpcRDeviceDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRDeviceDTO.Builder builder = GrpcRDeviceDTO.newBuilder();
+            GrpcR result;
 
-        DriverBO driverBO = selectDriver(request.getDriverId());
-        DeviceBO entityBO = selectDevice(request.getDeviceId());
-        if (Objects.isNull(entityBO) || Objects.isNull(driverBO)
-                || !Objects.equals(entityBO.getDriverId(), driverBO.getId())
-                || !Objects.equals(entityBO.getTenantId(), driverBO.getTenantId())) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            DriverBO driverBO = selectDriver(request.getDriverId());
+            DeviceBO entityBO = selectDevice(request.getDeviceId());
+            if (Objects.isNull(entityBO) || Objects.isNull(driverBO)
+                    || !Objects.equals(entityBO.getDriverId(), driverBO.getId())
+                    || !Objects.equals(entityBO.getTenantId(), driverBO.getTenantId())) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            builder.setData(getDeviceAttachDTO(entityBO));
+                builder.setData(getDeviceAttachDTO(entityBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     private boolean driverInTenant(Long tenantId, Long driverId) {

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/driver/DriverDriverServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/driver/DriverDriverServer.java
@@ -46,6 +46,7 @@ import io.github.pnoker.common.manager.service.DriverAttributeService;
 import io.github.pnoker.common.manager.service.DriverService;
 import io.github.pnoker.common.manager.service.EventAttributeService;
 import io.github.pnoker.common.manager.service.PointAttributeService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -153,27 +154,32 @@ public class DriverDriverServer extends DriverApiGrpc.DriverApiImplBase {
 
     @Override
     public void getById(GrpcDriverQuery request, StreamObserver<GrpcRDriverRegisterDTO> responseObserver) {
-        GrpcRDriverRegisterDTO.Builder builder = GrpcRDriverRegisterDTO.newBuilder();
-        GrpcR result;
-
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            DriverBO entityBO = driverService.getById(request.getDriverId());
-            if (Objects.isNull(entityBO)) {
-                result = GrpcRFactory.notFound();
-            } else {
-                buildMetadataResponse(builder, entityBO);
+            GrpcRDriverRegisterDTO.Builder builder = GrpcRDriverRegisterDTO.newBuilder();
+            GrpcR result;
 
-                result = GrpcRFactory.ok();
+            try {
+                DriverBO entityBO = driverService.getById(request.getDriverId());
+                if (Objects.isNull(entityBO)) {
+                    result = GrpcRFactory.notFound();
+                } else {
+                    buildMetadataResponse(builder, entityBO);
+
+                    result = GrpcRFactory.ok();
+                }
+            } catch (Exception e) {
+                result = GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage());
+
+                log.error("Driver metadata gRPC query failed, driverId={}", request.getDriverId(), e);
             }
-        } catch (Exception e) {
-            result = GrpcRFactory.fail(ErrorCode.FAILURE, e.getMessage());
 
-            log.error("Driver metadata gRPC query failed, driverId={}", request.getDriverId(), e);
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     private void buildMetadataResponse(GrpcRDriverRegisterDTO.Builder builder, DriverBO entityBO) {

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/driver/DriverPointServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/driver/DriverPointServer.java
@@ -36,6 +36,7 @@ import io.github.pnoker.common.manager.grpc.builder.GrpcPointBuilder;
 import io.github.pnoker.common.manager.service.DeviceService;
 import io.github.pnoker.common.manager.service.DriverService;
 import io.github.pnoker.common.manager.service.PointService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,59 +71,69 @@ public class DriverPointServer extends PointApiGrpc.PointApiImplBase {
 
     @Override
     public void listByPage(GrpcPagePointQuery request, StreamObserver<GrpcRPagePointDTO> responseObserver) {
-        GrpcRPagePointDTO.Builder builder = GrpcRPagePointDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPagePointDTO.Builder builder = GrpcRPagePointDTO.newBuilder();
+            GrpcR result;
 
-        PointQuery query = grpcPointBuilder.buildQueryByGrpcQuery(request);
+            PointQuery query = grpcPointBuilder.buildQueryByGrpcQuery(request);
 
-        Page<PointBO> entityPage = selectDriverScopedPage(request, query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<PointBO> entityPage = selectDriverScopedPage(request, query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPagePointDTO.Builder pageBuilder = GrpcPagePointDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pageBuilder.setPage(page);
+                GrpcPagePointDTO.Builder pageBuilder = GrpcPagePointDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pageBuilder.setPage(page);
 
-            List<GrpcPointDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(grpcPointBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pageBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcPointDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(grpcPointBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pageBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pageBuilder);
+                builder.setData(pageBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getById(GrpcPointQuery request, StreamObserver<GrpcRPointDTO> responseObserver) {
-        GrpcRPointDTO.Builder builder = GrpcRPointDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPointDTO.Builder builder = GrpcRPointDTO.newBuilder();
+            GrpcR result;
 
-        DriverBO driverBO = selectDriver(request.getDriverId());
-        PointBO entityBO = selectPoint(request.getPointId());
-        if (Objects.isNull(entityBO) || Objects.isNull(driverBO)
-                || !Objects.equals(entityBO.getTenantId(), driverBO.getTenantId())
-                || !driverHasPoint(driverBO, entityBO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            DriverBO driverBO = selectDriver(request.getDriverId());
+            PointBO entityBO = selectPoint(request.getPointId());
+            if (Objects.isNull(entityBO) || Objects.isNull(driverBO)
+                    || !Objects.equals(entityBO.getTenantId(), driverBO.getTenantId())
+                    || !driverHasPoint(driverBO, entityBO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            builder.setData(grpcPointBuilder.buildGrpcDTOByBO(entityBO));
+                builder.setData(grpcPointBuilder.buildGrpcDTOByBO(entityBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     private Page<PointBO> selectDriverScopedPage(GrpcPagePointQuery request, PointQuery query) {

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerCommandServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerCommandServer.java
@@ -35,6 +35,7 @@ import io.github.pnoker.common.manager.entity.bo.CommandBO;
 import io.github.pnoker.common.manager.entity.query.CommandQuery;
 import io.github.pnoker.common.manager.grpc.builder.GrpcCommandBuilder;
 import io.github.pnoker.common.manager.service.CommandService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,84 +63,99 @@ public class ManagerCommandServer extends CommandApiGrpc.CommandApiImplBase {
 
     @Override
     public void listByPage(GrpcPageCommandQuery request, StreamObserver<GrpcRPageCommandDTO> responseObserver) {
-        GrpcRPageCommandDTO.Builder builder = GrpcRPageCommandDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPageCommandDTO.Builder builder = GrpcRPageCommandDTO.newBuilder();
+            GrpcR result;
 
-        CommandQuery query = grpcCommandBuilder.buildQueryByGrpcQuery(request);
+            CommandQuery query = grpcCommandBuilder.buildQueryByGrpcQuery(request);
 
-        Page<CommandBO> entityPage = commandService.list(query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<CommandBO> entityPage = commandService.list(query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPageCommandDTO.Builder pageCommandBuilder = GrpcPageCommandDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pageCommandBuilder.setPage(page);
+                GrpcPageCommandDTO.Builder pageCommandBuilder = GrpcPageCommandDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pageCommandBuilder.setPage(page);
 
-            List<GrpcCommandDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(grpcCommandBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pageCommandBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcCommandDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(grpcCommandBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pageCommandBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pageCommandBuilder);
+                builder.setData(pageCommandBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByIds(GrpcCommandIdsQuery request, StreamObserver<GrpcRCommandListDTO> responseObserver) {
-        GrpcRCommandListDTO.Builder builder = GrpcRCommandListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRCommandListDTO.Builder builder = GrpcRCommandListDTO.newBuilder();
+            GrpcR result;
 
-        List<CommandBO> entityBOList = commandService.listByIds(new HashSet<>(request.getCommandIdsList()));
-        if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<CommandBO> entityBOList = commandService.listByIds(new HashSet<>(request.getCommandIdsList()));
+            if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcCommandDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcCommandBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcCommandDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcCommandBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getById(GrpcCommandQuery request, StreamObserver<GrpcRCommandDTO> responseObserver) {
-        GrpcRCommandDTO.Builder builder = GrpcRCommandDTO.newBuilder();
-        GrpcR result;
-
-        CommandBO entityBO;
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            entityBO = commandService.getById(request.getCommandId());
-        } catch (NotFoundException e) {
-            entityBO = null;
-        }
-        if (Objects.isNull(entityBO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            GrpcRCommandDTO.Builder builder = GrpcRCommandDTO.newBuilder();
+            GrpcR result;
 
-            builder.setData(grpcCommandBuilder.buildGrpcDTOByBO(entityBO));
-        }
+            CommandBO entityBO;
+            try {
+                entityBO = commandService.getById(request.getCommandId());
+            } catch (NotFoundException e) {
+                entityBO = null;
+            }
+            if (Objects.isNull(entityBO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+                builder.setData(grpcCommandBuilder.buildGrpcDTOByBO(entityBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerDeviceServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerDeviceServer.java
@@ -37,6 +37,7 @@ import io.github.pnoker.common.manager.entity.bo.DeviceBO;
 import io.github.pnoker.common.manager.entity.query.DeviceQuery;
 import io.github.pnoker.common.manager.grpc.builder.GrpcDeviceBuilder;
 import io.github.pnoker.common.manager.service.DeviceService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,130 +65,155 @@ public class ManagerDeviceServer extends DeviceApiGrpc.DeviceApiImplBase {
 
     @Override
     public void listByPage(GrpcPageDeviceQuery request, StreamObserver<GrpcRPageDeviceDTO> responseObserver) {
-        GrpcRPageDeviceDTO.Builder builder = GrpcRPageDeviceDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPageDeviceDTO.Builder builder = GrpcRPageDeviceDTO.newBuilder();
+            GrpcR result;
 
-        DeviceQuery query = grpcDeviceBuilder.buildQueryByGrpcQuery(request);
+            DeviceQuery query = grpcDeviceBuilder.buildQueryByGrpcQuery(request);
 
-        Page<DeviceBO> entityPage = deviceService.list(query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<DeviceBO> entityPage = deviceService.list(query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPageDeviceDTO.Builder pageBuilder = GrpcPageDeviceDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pageBuilder.setPage(page);
+                GrpcPageDeviceDTO.Builder pageBuilder = GrpcPageDeviceDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pageBuilder.setPage(page);
 
-            List<GrpcDeviceDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(grpcDeviceBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pageBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcDeviceDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(grpcDeviceBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pageBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pageBuilder);
+                builder.setData(pageBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByDriverId(GrpcDriverQuery driver, StreamObserver<GrpcRDeviceListDTO> responseObserver) {
-        GrpcRDeviceListDTO.Builder builder = GrpcRDeviceListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(driver.getTenantId());
+        try {
+            GrpcRDeviceListDTO.Builder builder = GrpcRDeviceListDTO.newBuilder();
+            GrpcR result;
 
-        List<DeviceBO> entityBOList = deviceService.listByDriverId(driver.getDriverId(), null);
-        if (CollectionUtils.isEmpty(entityBOList)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<DeviceBO> entityBOList = deviceService.listByDriverId(driver.getDriverId(), null);
+            if (CollectionUtils.isEmpty(entityBOList)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcDeviceDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcDeviceBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcDeviceDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcDeviceBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByProfileId(GrpcProfileQuery request, StreamObserver<GrpcRDeviceListDTO> responseObserver) {
-        GrpcRDeviceListDTO.Builder builder = GrpcRDeviceListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRDeviceListDTO.Builder builder = GrpcRDeviceListDTO.newBuilder();
+            GrpcR result;
 
-        List<DeviceBO> entityBOList = deviceService.listByProfileId(request.getProfileId(), null);
-        if (CollectionUtils.isEmpty(entityBOList)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<DeviceBO> entityBOList = deviceService.listByProfileId(request.getProfileId(), null);
+            if (CollectionUtils.isEmpty(entityBOList)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcDeviceDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcDeviceBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcDeviceDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcDeviceBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByDeviceIds(GrpcDeviceIdsQuery request, StreamObserver<GrpcRDeviceListDTO> responseObserver) {
-        GrpcRDeviceListDTO.Builder builder = GrpcRDeviceListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRDeviceListDTO.Builder builder = GrpcRDeviceListDTO.newBuilder();
+            GrpcR result;
 
-        List<DeviceBO> entityBOList = deviceService.listByIds(request.getDeviceIdsList().stream().distinct().toList());
-        if (CollectionUtils.isEmpty(entityBOList)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<DeviceBO> entityBOList = deviceService.listByIds(request.getDeviceIdsList().stream().distinct().toList());
+            if (CollectionUtils.isEmpty(entityBOList)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcDeviceDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcDeviceBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcDeviceDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcDeviceBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getByDeviceId(GrpcDeviceQuery request, StreamObserver<GrpcRDeviceDTO> responseObserver) {
-        GrpcRDeviceDTO.Builder builder = GrpcRDeviceDTO.newBuilder();
-        GrpcR result;
-
-        DeviceBO entityBO;
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            entityBO = deviceService.getById(request.getDeviceId());
-        } catch (NotFoundException e) {
-            entityBO = null;
-        }
-        if (Objects.isNull(entityBO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            GrpcRDeviceDTO.Builder builder = GrpcRDeviceDTO.newBuilder();
+            GrpcR result;
 
-            builder.setData(grpcDeviceBuilder.buildGrpcDTOByBO(entityBO));
-        }
+            DeviceBO entityBO;
+            try {
+                entityBO = deviceService.getById(request.getDeviceId());
+            } catch (NotFoundException e) {
+                entityBO = null;
+            }
+            if (Objects.isNull(entityBO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+                builder.setData(grpcDeviceBuilder.buildGrpcDTOByBO(entityBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerDriverServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerDriverServer.java
@@ -36,6 +36,7 @@ import io.github.pnoker.common.manager.entity.bo.DriverBO;
 import io.github.pnoker.common.manager.entity.query.DriverQuery;
 import io.github.pnoker.common.manager.grpc.builder.GrpcDriverBuilder;
 import io.github.pnoker.common.manager.service.DriverService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,103 +64,123 @@ public class ManagerDriverServer extends DriverApiGrpc.DriverApiImplBase {
 
     @Override
     public void listByPage(GrpcPageDriverQuery request, StreamObserver<GrpcRPageDriverDTO> responseObserver) {
-        GrpcRPageDriverDTO.Builder builder = GrpcRPageDriverDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPageDriverDTO.Builder builder = GrpcRPageDriverDTO.newBuilder();
+            GrpcR result;
 
-        DriverQuery query = grpcDriverBuilder.buildQueryByGrpcQuery(request);
+            DriverQuery query = grpcDriverBuilder.buildQueryByGrpcQuery(request);
 
-        Page<DriverBO> entityPage = driverService.list(query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<DriverBO> entityPage = driverService.list(query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPageDriverDTO.Builder pageBuilder = GrpcPageDriverDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pageBuilder.setPage(page);
+                GrpcPageDriverDTO.Builder pageBuilder = GrpcPageDriverDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pageBuilder.setPage(page);
 
-            List<GrpcDriverDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(grpcDriverBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pageBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcDriverDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(grpcDriverBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pageBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pageBuilder);
+                builder.setData(pageBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getByDeviceId(GrpcDeviceQuery request, StreamObserver<GrpcRDriverDTO> responseObserver) {
-        GrpcRDriverDTO.Builder builder = GrpcRDriverDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRDriverDTO.Builder builder = GrpcRDriverDTO.newBuilder();
+            GrpcR result;
 
-        DriverBO entityDO = driverService.getByDeviceId(request.getDeviceId(), null);
-        if (Objects.isNull(entityDO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            DriverBO entityDO = driverService.getByDeviceId(request.getDeviceId(), null);
+            if (Objects.isNull(entityDO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            builder.setData(grpcDriverBuilder.buildGrpcDTOByBO(entityDO));
+                builder.setData(grpcDriverBuilder.buildGrpcDTOByBO(entityDO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByDriverIds(GrpcDriverIdsQuery request, StreamObserver<GrpcRDriverListDTO> responseObserver) {
-        GrpcRDriverListDTO.Builder builder = GrpcRDriverListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRDriverListDTO.Builder builder = GrpcRDriverListDTO.newBuilder();
+            GrpcR result;
 
-        List<DriverBO> entityBOList = driverService.listByIds(new HashSet<>(request.getDriverIdsList()));
-        if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<DriverBO> entityBOList = driverService.listByIds(new HashSet<>(request.getDriverIdsList()));
+            if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcDriverDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcDriverBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcDriverDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcDriverBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getByDriverId(GrpcDriverQuery request, StreamObserver<GrpcRDriverDTO> responseObserver) {
-        GrpcRDriverDTO.Builder builder = GrpcRDriverDTO.newBuilder();
-        GrpcR result;
-
-        DriverBO driverBO;
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            driverBO = driverService.getById(request.getDriverId());
-        } catch (NotFoundException e) {
-            driverBO = null;
-        }
-        if (Objects.isNull(driverBO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            GrpcRDriverDTO.Builder builder = GrpcRDriverDTO.newBuilder();
+            GrpcR result;
 
-            builder.setData(grpcDriverBuilder.buildGrpcDTOByBO(driverBO));
-        }
+            DriverBO driverBO;
+            try {
+                driverBO = driverService.getById(request.getDriverId());
+            } catch (NotFoundException e) {
+                driverBO = null;
+            }
+            if (Objects.isNull(driverBO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+                builder.setData(grpcDriverBuilder.buildGrpcDTOByBO(driverBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerEventServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerEventServer.java
@@ -35,6 +35,7 @@ import io.github.pnoker.common.manager.entity.bo.EventBO;
 import io.github.pnoker.common.manager.entity.query.EventQuery;
 import io.github.pnoker.common.manager.grpc.builder.GrpcEventBuilder;
 import io.github.pnoker.common.manager.service.EventService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,84 +63,99 @@ public class ManagerEventServer extends EventApiGrpc.EventApiImplBase {
 
     @Override
     public void listByPage(GrpcPageEventQuery request, StreamObserver<GrpcRPageEventDTO> responseObserver) {
-        GrpcRPageEventDTO.Builder builder = GrpcRPageEventDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPageEventDTO.Builder builder = GrpcRPageEventDTO.newBuilder();
+            GrpcR result;
 
-        EventQuery query = grpcEventBuilder.buildQueryByGrpcQuery(request);
+            EventQuery query = grpcEventBuilder.buildQueryByGrpcQuery(request);
 
-        Page<EventBO> entityPage = eventService.list(query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<EventBO> entityPage = eventService.list(query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPageEventDTO.Builder pageEventBuilder = GrpcPageEventDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pageEventBuilder.setPage(page);
+                GrpcPageEventDTO.Builder pageEventBuilder = GrpcPageEventDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pageEventBuilder.setPage(page);
 
-            List<GrpcEventDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(grpcEventBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pageEventBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcEventDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(grpcEventBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pageEventBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pageEventBuilder);
+                builder.setData(pageEventBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByIds(GrpcEventIdsQuery request, StreamObserver<GrpcREventListDTO> responseObserver) {
-        GrpcREventListDTO.Builder builder = GrpcREventListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcREventListDTO.Builder builder = GrpcREventListDTO.newBuilder();
+            GrpcR result;
 
-        List<EventBO> entityBOList = eventService.listByIds(new HashSet<>(request.getEventIdsList()));
-        if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<EventBO> entityBOList = eventService.listByIds(new HashSet<>(request.getEventIdsList()));
+            if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcEventDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcEventBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcEventDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcEventBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getById(GrpcEventQuery request, StreamObserver<GrpcREventDTO> responseObserver) {
-        GrpcREventDTO.Builder builder = GrpcREventDTO.newBuilder();
-        GrpcR result;
-
-        EventBO entityBO;
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            entityBO = eventService.getById(request.getEventId());
-        } catch (NotFoundException e) {
-            entityBO = null;
-        }
-        if (Objects.isNull(entityBO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            GrpcREventDTO.Builder builder = GrpcREventDTO.newBuilder();
+            GrpcR result;
 
-            builder.setData(grpcEventBuilder.buildGrpcDTOByBO(entityBO));
-        }
+            EventBO entityBO;
+            try {
+                entityBO = eventService.getById(request.getEventId());
+            } catch (NotFoundException e) {
+                entityBO = null;
+            }
+            if (Objects.isNull(entityBO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+                builder.setData(grpcEventBuilder.buildGrpcDTOByBO(entityBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerPointServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerPointServer.java
@@ -35,6 +35,7 @@ import io.github.pnoker.common.manager.entity.bo.PointBO;
 import io.github.pnoker.common.manager.entity.query.PointQuery;
 import io.github.pnoker.common.manager.grpc.builder.GrpcPointBuilder;
 import io.github.pnoker.common.manager.service.PointService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,84 +63,99 @@ public class ManagerPointServer extends PointApiGrpc.PointApiImplBase {
 
     @Override
     public void listByPage(GrpcPagePointQuery request, StreamObserver<GrpcRPagePointDTO> responseObserver) {
-        GrpcRPagePointDTO.Builder builder = GrpcRPagePointDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPagePointDTO.Builder builder = GrpcRPagePointDTO.newBuilder();
+            GrpcR result;
 
-        PointQuery query = grpcPointBuilder.buildQueryByGrpcQuery(request);
+            PointQuery query = grpcPointBuilder.buildQueryByGrpcQuery(request);
 
-        Page<PointBO> entityPage = pointService.list(query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            Page<PointBO> entityPage = pointService.list(query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            GrpcPagePointDTO.Builder pagePointBuilder = GrpcPagePointDTO.newBuilder();
-            GrpcPage.Builder page = GrpcPage.newBuilder();
-            page.setCurrent(entityPage.getCurrent());
-            page.setSize(entityPage.getSize());
-            page.setPages(entityPage.getPages());
-            page.setTotal(entityPage.getTotal());
-            pagePointBuilder.setPage(page);
+                GrpcPagePointDTO.Builder pagePointBuilder = GrpcPagePointDTO.newBuilder();
+                GrpcPage.Builder page = GrpcPage.newBuilder();
+                page.setCurrent(entityPage.getCurrent());
+                page.setSize(entityPage.getSize());
+                page.setPages(entityPage.getPages());
+                page.setTotal(entityPage.getTotal());
+                pagePointBuilder.setPage(page);
 
-            List<GrpcPointDTO> entityGrpcDTOList = entityPage.getRecords()
-                    .stream()
-                    .map(grpcPointBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pagePointBuilder.addAllData(entityGrpcDTOList);
+                List<GrpcPointDTO> entityGrpcDTOList = entityPage.getRecords()
+                        .stream()
+                        .map(grpcPointBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pagePointBuilder.addAllData(entityGrpcDTOList);
 
-            builder.setData(pagePointBuilder);
+                builder.setData(pagePointBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByIds(GrpcPointIdsQuery request, StreamObserver<GrpcRPointListDTO> responseObserver) {
-        GrpcRPointListDTO.Builder builder = GrpcRPointListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPointListDTO.Builder builder = GrpcRPointListDTO.newBuilder();
+            GrpcR result;
 
-        List<PointBO> entityBOList = pointService.listByIds(new HashSet<>(request.getPointIdsList()));
-        if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            List<PointBO> entityBOList = pointService.listByIds(new HashSet<>(request.getPointIdsList()));
+            if (Objects.isNull(entityBOList) || entityBOList.isEmpty()) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-            List<GrpcPointDTO> entityGrpcDTOList = entityBOList.stream()
-                    .map(grpcPointBuilder::buildGrpcDTOByBO)
-                    .toList();
+                List<GrpcPointDTO> entityGrpcDTOList = entityBOList.stream()
+                        .map(grpcPointBuilder::buildGrpcDTOByBO)
+                        .toList();
 
-            builder.addAllData(entityGrpcDTOList);
+                builder.addAllData(entityGrpcDTOList);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getById(GrpcPointQuery request, StreamObserver<GrpcRPointDTO> responseObserver) {
-        GrpcRPointDTO.Builder builder = GrpcRPointDTO.newBuilder();
-        GrpcR result;
-
-        PointBO entityBO;
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            entityBO = pointService.getById(request.getPointId());
-        } catch (NotFoundException e) {
-            entityBO = null;
-        }
-        if (Objects.isNull(entityBO)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
+            GrpcRPointDTO.Builder builder = GrpcRPointDTO.newBuilder();
+            GrpcR result;
 
-            builder.setData(grpcPointBuilder.buildGrpcDTOByBO(entityBO));
-        }
+            PointBO entityBO;
+            try {
+                entityBO = pointService.getById(request.getPointId());
+            } catch (NotFoundException e) {
+                entityBO = null;
+            }
+            if (Objects.isNull(entityBO)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
 
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+                builder.setData(grpcPointBuilder.buildGrpcDTOByBO(entityBO));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
 }

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerProfileServer.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/grpc/server/manager/ManagerProfileServer.java
@@ -35,6 +35,7 @@ import io.github.pnoker.common.manager.entity.bo.ProfileBO;
 import io.github.pnoker.common.manager.entity.query.ProfileQuery;
 import io.github.pnoker.common.manager.grpc.builder.GrpcProfileBuilder;
 import io.github.pnoker.common.manager.service.ProfileService;
+import io.github.pnoker.common.tenant.TenantContextHolder;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,87 +64,107 @@ public class ManagerProfileServer extends ProfileApiGrpc.ProfileApiImplBase {
 
     @Override
     public void listByPage(GrpcPageProfileQuery request, StreamObserver<GrpcRPageProfileDTO> responseObserver) {
-        GrpcRPageProfileDTO.Builder builder = GrpcRPageProfileDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRPageProfileDTO.Builder builder = GrpcRPageProfileDTO.newBuilder();
+            GrpcR result;
 
-        ProfileQuery query = grpcProfileBuilder.buildQueryByGrpcQuery(request);
-        Page<ProfileBO> entityPage = profileService.list(query);
-        if (Objects.isNull(entityPage)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
-            GrpcPageProfileDTO.Builder pageBuilder = GrpcPageProfileDTO.newBuilder();
-            pageBuilder.setPage(grpcProfileBuilder.buildGrpcPage(entityPage));
-            List<GrpcProfileDTO> profiles = entityPage.getRecords().stream()
-                    .map(grpcProfileBuilder::buildGrpcDTOByBO)
-                    .toList();
-            pageBuilder.addAllData(profiles);
-            builder.setData(pageBuilder);
+            ProfileQuery query = grpcProfileBuilder.buildQueryByGrpcQuery(request);
+            Page<ProfileBO> entityPage = profileService.list(query);
+            if (Objects.isNull(entityPage)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
+                GrpcPageProfileDTO.Builder pageBuilder = GrpcPageProfileDTO.newBuilder();
+                pageBuilder.setPage(grpcProfileBuilder.buildGrpcPage(entityPage));
+                List<GrpcProfileDTO> profiles = entityPage.getRecords().stream()
+                        .map(grpcProfileBuilder::buildGrpcDTOByBO)
+                        .toList();
+                pageBuilder.addAllData(profiles);
+                builder.setData(pageBuilder);
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void getByProfileId(GrpcProfileQuery request, StreamObserver<GrpcRProfileDTO> responseObserver) {
-        GrpcRProfileDTO.Builder builder = GrpcRProfileDTO.newBuilder();
-        GrpcR result;
-
-        ProfileBO profile;
+        TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            profile = profileService.getById(request.getProfileId());
-        } catch (NotFoundException e) {
-            profile = null;
-        }
-        if (Objects.isNull(profile)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
-            builder.setData(grpcProfileBuilder.buildGrpcDTOByBO(profile));
-        }
+            GrpcRProfileDTO.Builder builder = GrpcRProfileDTO.newBuilder();
+            GrpcR result;
 
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+            ProfileBO profile;
+            try {
+                profile = profileService.getById(request.getProfileId());
+            } catch (NotFoundException e) {
+                profile = null;
+            }
+            if (Objects.isNull(profile)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
+                builder.setData(grpcProfileBuilder.buildGrpcDTOByBO(profile));
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     @Override
     public void listByProfileIds(GrpcProfileIdsQuery request,
                                  StreamObserver<GrpcRProfileListDTO> responseObserver) {
-        GrpcRProfileListDTO.Builder builder = GrpcRProfileListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRProfileListDTO.Builder builder = GrpcRProfileListDTO.newBuilder();
+            GrpcR result;
 
-        List<ProfileBO> profiles = profileService.listByIds(new HashSet<>(request.getProfileIdsList()));
-        if (CollectionUtils.isEmpty(profiles)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
-            builder.addAllData(profiles.stream().map(grpcProfileBuilder::buildGrpcDTOByBO).toList());
+            List<ProfileBO> profiles = profileService.listByIds(new HashSet<>(request.getProfileIdsList()));
+            if (CollectionUtils.isEmpty(profiles)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
+                builder.addAllData(profiles.stream().map(grpcProfileBuilder::buildGrpcDTOByBO).toList());
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
     @Override
     public void listByDeviceId(GrpcDeviceQuery request, StreamObserver<GrpcRProfileListDTO> responseObserver) {
-        GrpcRProfileListDTO.Builder builder = GrpcRProfileListDTO.newBuilder();
-        GrpcR result;
+        TenantContextHolder.setTenantId(request.getTenantId());
+        try {
+            GrpcRProfileListDTO.Builder builder = GrpcRProfileListDTO.newBuilder();
+            GrpcR result;
 
-        List<ProfileBO> profiles = profileService.listByDeviceId(request.getDeviceId());
-        if (CollectionUtils.isEmpty(profiles)) {
-            result = GrpcRFactory.notFound();
-        } else {
-            result = GrpcRFactory.ok();
-            builder.addAllData(profiles.stream().map(grpcProfileBuilder::buildGrpcDTOByBO).toList());
+            List<ProfileBO> profiles = profileService.listByDeviceId(request.getDeviceId());
+            if (CollectionUtils.isEmpty(profiles)) {
+                result = GrpcRFactory.notFound();
+            } else {
+                result = GrpcRFactory.ok();
+                builder.addAllData(profiles.stream().map(grpcProfileBuilder::buildGrpcDTOByBO).toList());
+            }
+
+            builder.setResult(result);
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } finally {
+            TenantContextHolder.clear();
         }
-
-        builder.setResult(result);
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
     }
 
 }

--- a/dc3-common/dc3-common-postgres/pom.xml
+++ b/dc3-common/dc3-common-postgres/pom.xml
@@ -118,6 +118,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/dc3-common/dc3-common-postgres/src/test/java/io/github/pnoker/common/config/TenantLineInterceptorIntegrationTest.java
+++ b/dc3-common/dc3-common-postgres/src/test/java/io/github/pnoker/common/config/TenantLineInterceptorIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.pnoker.common.config;
+
+import io.github.pnoker.common.exception.TenantNotScopedException;
+import io.github.pnoker.common.tenant.TenantContextHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration test exercising the tenant-line interceptor across the full MyBatis-Plus SQL
+ * pipeline (not just the handler in isolation): the fail-closed path and the scoped-query
+ * path that the Mockito-only unit tests of the gRPC layer cannot reach.
+ */
+@SpringBootTest
+@SpringBootConfiguration
+@EnableAutoConfiguration(excludeName = "com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceAutoConfiguration")
+@Import({MybatisPlusConfig.class, TenantLineHandlerImpl.class})
+@MapperScan(basePackageClasses = TestMapper.class)
+class TenantLineInterceptorIntegrationTest {
+
+    @Autowired
+    private TestMapper mapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void seed() {
+        jdbcTemplate.execute("CREATE TABLE dc3_test_entity (id BIGINT PRIMARY KEY, tenant_id BIGINT, name VARCHAR(32))");
+        // Insert via JdbcTemplate so the rows bypass the tenant-line interceptor and we can
+        // assert the interceptor filters them on read.
+        jdbcTemplate.update("INSERT INTO dc3_test_entity (id, tenant_id, name) VALUES (1, 7, 'tenant-seven')");
+        jdbcTemplate.update("INSERT INTO dc3_test_entity (id, tenant_id, name) VALUES (2, 8, 'tenant-eight')");
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContextHolder.clear();
+        jdbcTemplate.execute("DROP TABLE dc3_test_entity");
+    }
+
+    @Test
+    void selectListFiltersRowsToBoundTenant() {
+        TenantContextHolder.setTenantId(7L);
+        try {
+            List<TestEntityDO> rows = mapper.selectList(null);
+            assertThat(rows).hasSize(1);
+            assertThat(rows.get(0).getId()).isEqualTo(1L);
+            assertThat(rows.get(0).getTenantId()).isEqualTo(7L);
+        } finally {
+            TenantContextHolder.clear();
+        }
+    }
+
+    @Test
+    void selectListRejectsUnscopedQuery() {
+        // No tenant bound and not inside runIgnore → the interceptor must fail closed rather
+        // than let the query leak across tenants. mybatis-spring wraps the interceptor's
+        // TenantNotScopedException in MyBatisSystemException, so assert on the root cause.
+        assertThatThrownBy(() -> mapper.selectList(null))
+                .hasRootCauseInstanceOf(TenantNotScopedException.class);
+    }
+
+    @Test
+    void selectListReturnsAllRowsInsideRunIgnore() {
+        TenantContextHolder.runIgnoreAction(() -> {
+            List<TestEntityDO> rows = mapper.selectList(null);
+            assertThat(rows).hasSize(2);
+        });
+    }
+}

--- a/dc3-common/dc3-common-postgres/src/test/java/io/github/pnoker/common/config/TestEntityDO.java
+++ b/dc3-common/dc3-common-postgres/src/test/java/io/github/pnoker/common/config/TestEntityDO.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.pnoker.common.config;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Tenant-scoped test entity — backed by an H2 table created in the integration test so the
+ * tenant-line interceptor has a non-whitelisted table to inject {@code tenant_id} into.
+ */
+@Getter
+@Setter
+@TableName("dc3_test_entity")
+public class TestEntityDO {
+
+    @TableId(type = IdType.INPUT)
+    private Long id;
+
+    private Long tenantId;
+
+    private String name;
+}

--- a/dc3-common/dc3-common-postgres/src/test/java/io/github/pnoker/common/config/TestMapper.java
+++ b/dc3-common/dc3-common-postgres/src/test/java/io/github/pnoker/common/config/TestMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) to later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.pnoker.common.config;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * MyBatis-Plus mapper for {@link TestEntityDO}; {@link BaseMapper#selectList} runs through
+ * the configured {@link com.baomidou.mybatisplus.extension.plugins.inner.TenantLineInnerInterceptor}.
+ */
+@Mapper
+public interface TestMapper extends BaseMapper<TestEntityDO> {
+}


### PR DESCRIPTION
D-1 fail-closed interceptor + gRPC server no BaseController.async tenant binding caused silent failures on all tenant-scoped tables. Bind tenant: proto tenant_id, facade R1 dual-param, 9 servers setTenantId, data/TokenServer, driver clients, alarm drop reverse-resolve, +H2 integration test. Build green common+center+mqtt. Unit tests manager139/auth92/agentic213/data247 + integration 3/3 green.