### PR TITLE
chore(ci): route dependabot PRs to develop (fix main-only BLOCKED)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -11,6 +12,7 @@ updates:
 
   - package-ecosystem: npm
     directory: /docs
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -20,6 +22,7 @@ updates:
 
   - package-ecosystem: npm
     directory: /dc3-web
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -29,6 +32,7 @@ updates:
 
   - package-ecosystem: maven
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -42,6 +46,7 @@ updates:
       - /dc3-web
       - /dc3/dependencies/rabbitmq
       - /dc3/dependencies/postgres
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## 问题
`dependabot.yml` 没有 `target-branch`,所有依赖升级 PR 默认开到**默认分支 main**。而 main 是发版分支、且当前编译失败(修复只在 develop),导致 **17 个 dependabot PR 全部 BLOCKED**。

## 修复
给 5 个 ecosystem(github-actions / npm×2 / maven / docker)都加 `target-branch: develop`。

## 效果
依赖升级以后开到 **develop**(集成分支)验证编译/测试 → 通过后 promote 到 main 发版。符合 git flow,且避开编译失败的 main。

## ⚠️ 需同步 develop
本 PR 改的是 main(默认分支,dependabot 在此读配置)。合并后 **develop 的 dependabot.yml 仍是旧版**,下次 promote develop→main 时该文件会冲突。建议合并后把同样改动同步到 develop(或下次 promote 时取带 target-branch 版)。

## 关联
- 根因背景见 #150(promote develop→main,已让 main 恢复编译)
- 合并 #150 + 本 PR 后,11 个 BLOCKED 的 dependabot PR 可在 develop 重开/重跑