### PR TITLE
build(deps): bump mybatis-plus 3.5.16 → 3.5.17 + adapt imports

### DIFF
--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/ActionManager.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/ActionManager.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.agentic.entity.model.ActionDO;
 
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/AttachmentManager.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/AttachmentManager.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.agentic.entity.model.AttachmentDO;
 
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/MessageManager.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/MessageManager.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.agentic.entity.model.MessageDO;
 
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/ModelConfigManager.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/ModelConfigManager.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.agentic.entity.model.ModelConfigDO;
 
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/ModelProviderManager.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/ModelProviderManager.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.agentic.entity.model.ModelProviderDO;
 
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/SessionManager.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/SessionManager.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.agentic.entity.model.SessionDO;
 
 /**

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/ActionManagerImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/ActionManagerImpl.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.agentic.dal.ActionManager;
 import io.github.pnoker.common.agentic.entity.model.ActionDO;
 import io.github.pnoker.common.agentic.mapper.ActionMapper;

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/AttachmentManagerImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/AttachmentManagerImpl.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.agentic.dal.AttachmentManager;
 import io.github.pnoker.common.agentic.entity.model.AttachmentDO;
 import io.github.pnoker.common.agentic.mapper.AttachmentMapper;

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/MessageManagerImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/MessageManagerImpl.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.agentic.dal.MessageManager;
 import io.github.pnoker.common.agentic.entity.model.MessageDO;
 import io.github.pnoker.common.agentic.mapper.MessageMapper;

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/ModelConfigManagerImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/ModelConfigManagerImpl.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.agentic.dal.ModelConfigManager;
 import io.github.pnoker.common.agentic.entity.model.ModelConfigDO;
 import io.github.pnoker.common.agentic.mapper.ModelConfigMapper;

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/ModelProviderManagerImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/ModelProviderManagerImpl.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.agentic.dal.ModelProviderManager;
 import io.github.pnoker.common.agentic.entity.model.ModelProviderDO;
 import io.github.pnoker.common.agentic.mapper.ModelProviderMapper;

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/SessionManagerImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/dal/impl/SessionManagerImpl.java
@@ -16,7 +16,7 @@
  */
 package io.github.pnoker.common.agentic.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.agentic.dal.SessionManager;
 import io.github.pnoker.common.agentic.entity.model.SessionDO;
 import io.github.pnoker.common.agentic.mapper.SessionMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ApiManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ApiManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.ApiDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/DriverTokenManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/DriverTokenManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.DriverTokenDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ExternalIdentityManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ExternalIdentityManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.ExternalIdentityDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/IdentityAuditLogManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/IdentityAuditLogManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.IdentityAuditLogDO;
 
 import java.util.List;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/IdentityProviderManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/IdentityProviderManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.IdentityProviderDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/LocalCredentialManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/LocalCredentialManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.LocalCredentialDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/MenuManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/MenuManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.MenuDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/PrincipalManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/PrincipalManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.PrincipalDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ResourceManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ResourceManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.ResourceDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/RoleManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/RoleManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.RoleDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/RolePrincipalBindManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/RolePrincipalBindManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.RolePrincipalBindDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/RoleResourceBindManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/RoleResourceBindManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.RoleResourceBindDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ServiceAccountManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/ServiceAccountManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.ServiceAccountDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/TenantManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/TenantManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.TenantDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/TenantMembershipManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/TenantMembershipManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.TenantMembershipDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/UserManager.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/UserManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.auth.entity.model.UserDO;
 
 /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ApiManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ApiManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.ApiManager;
 import io.github.pnoker.common.auth.entity.model.ApiDO;
 import io.github.pnoker.common.auth.mapper.ApiMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/DriverTokenManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/DriverTokenManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.DriverTokenManager;
 import io.github.pnoker.common.auth.entity.model.DriverTokenDO;
 import io.github.pnoker.common.auth.mapper.DriverTokenMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ExternalIdentityManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ExternalIdentityManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.ExternalIdentityManager;
 import io.github.pnoker.common.auth.entity.model.ExternalIdentityDO;
 import io.github.pnoker.common.auth.mapper.ExternalIdentityMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/IdentityAuditLogManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/IdentityAuditLogManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.IdentityAuditLogManager;
 import io.github.pnoker.common.auth.entity.model.IdentityAuditLogDO;
 import io.github.pnoker.common.auth.mapper.IdentityAuditLogMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/IdentityProviderManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/IdentityProviderManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.IdentityProviderManager;
 import io.github.pnoker.common.auth.entity.model.IdentityProviderDO;
 import io.github.pnoker.common.auth.mapper.IdentityProviderMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/LocalCredentialManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/LocalCredentialManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.LocalCredentialManager;
 import io.github.pnoker.common.auth.entity.model.LocalCredentialDO;
 import io.github.pnoker.common.auth.mapper.LocalCredentialMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/MenuManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/MenuManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.MenuManager;
 import io.github.pnoker.common.auth.entity.model.MenuDO;
 import io.github.pnoker.common.auth.mapper.MenuMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/PrincipalManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/PrincipalManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.PrincipalManager;
 import io.github.pnoker.common.auth.entity.model.PrincipalDO;
 import io.github.pnoker.common.auth.mapper.PrincipalMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ResourceManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ResourceManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.ResourceManager;
 import io.github.pnoker.common.auth.entity.model.ResourceDO;
 import io.github.pnoker.common.auth.mapper.ResourceMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/RoleManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/RoleManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.RoleManager;
 import io.github.pnoker.common.auth.entity.model.RoleDO;
 import io.github.pnoker.common.auth.mapper.RoleMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/RolePrincipalBindManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/RolePrincipalBindManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.RolePrincipalBindManager;
 import io.github.pnoker.common.auth.entity.model.RolePrincipalBindDO;
 import io.github.pnoker.common.auth.mapper.RolePrincipalBindMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/RoleResourceBindManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/RoleResourceBindManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.RoleResourceBindManager;
 import io.github.pnoker.common.auth.entity.model.RoleResourceBindDO;
 import io.github.pnoker.common.auth.mapper.RoleResourceBindMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ServiceAccountManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/ServiceAccountManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.ServiceAccountManager;
 import io.github.pnoker.common.auth.entity.model.ServiceAccountDO;
 import io.github.pnoker.common.auth.mapper.ServiceAccountMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/TenantManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/TenantManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.TenantManager;
 import io.github.pnoker.common.auth.entity.model.TenantDO;
 import io.github.pnoker.common.auth.mapper.TenantMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/TenantMembershipManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/TenantMembershipManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.TenantMembershipManager;
 import io.github.pnoker.common.auth.entity.model.TenantMembershipDO;
 import io.github.pnoker.common.auth.mapper.TenantMembershipMapper;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/UserManagerImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/dal/impl/UserManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.auth.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.auth.dal.UserManager;
 import io.github.pnoker.common.auth.entity.model.UserDO;
 import io.github.pnoker.common.auth.mapper.UserMapper;

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/GroupBindManager.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/GroupBindManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.dal.entity.model.GroupBindDO;
 
 /**

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/GroupManager.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/GroupManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.dal.entity.model.GroupDO;
 
 /**

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/LabelBindManager.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/LabelBindManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.dal.entity.model.LabelBindDO;
 
 /**

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/LabelManager.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/LabelManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.dal.entity.model.LabelDO;
 
 /**

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/GroupBindManagerImpl.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/GroupBindManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.dal.dal.GroupBindManager;
 import io.github.pnoker.common.dal.entity.model.GroupBindDO;
 import io.github.pnoker.common.dal.mapper.GroupBindMapper;

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/GroupManagerImpl.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/GroupManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.dal.dal.GroupManager;
 import io.github.pnoker.common.dal.entity.model.GroupDO;
 import io.github.pnoker.common.dal.mapper.GroupMapper;

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/LabelBindManagerImpl.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/LabelBindManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.dal.dal.LabelBindManager;
 import io.github.pnoker.common.dal.entity.model.LabelBindDO;
 import io.github.pnoker.common.dal.mapper.LabelBindMapper;

--- a/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/LabelManagerImpl.java
+++ b/dc3-common/dc3-common-dal/src/main/java/io/github/pnoker/common/dal/dal/impl/LabelManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.dal.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.dal.dal.LabelManager;
 import io.github.pnoker.common.dal.entity.model.LabelDO;
 import io.github.pnoker.common.dal.mapper.LabelMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/CommandHistoryManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/CommandHistoryManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.CommandHistoryDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/EntityAlarmManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/EntityAlarmManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.EntityAlarmDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/EntityStateManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/EntityStateManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.EntityStateDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/EventHistoryManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/EventHistoryManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.EventHistoryDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/MessageManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/MessageManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.MessageDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyChannelBindManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyChannelBindManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.NotifyChannelBindDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyChannelManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyChannelManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.NotifyChannelDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyHistoryManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyHistoryManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.NotifyHistoryDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/NotifyManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.NotifyDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/PointCommandHistoryManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/PointCommandHistoryManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.PointCommandHistoryDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/PointValueManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/PointValueManager.java
@@ -18,7 +18,7 @@
 package io.github.pnoker.common.data.dal;
 
 import com.baomidou.dynamic.datasource.annotation.DS;
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.PointValueDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/RuleManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/RuleManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.RuleDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/RuleStateManager.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/RuleStateManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.data.entity.model.RuleStateDO;
 
 /**

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/CommandHistoryManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/CommandHistoryManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.CommandHistoryManager;
 import io.github.pnoker.common.data.entity.model.CommandHistoryDO;
 import io.github.pnoker.common.data.mapper.CommandHistoryMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/EntityAlarmManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/EntityAlarmManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.EntityAlarmManager;
 import io.github.pnoker.common.data.entity.model.EntityAlarmDO;
 import io.github.pnoker.common.data.mapper.EntityAlarmMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/EntityStateManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/EntityStateManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.EntityStateManager;
 import io.github.pnoker.common.data.entity.model.EntityStateDO;
 import io.github.pnoker.common.data.mapper.EntityStateMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/EventHistoryManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/EventHistoryManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.EventHistoryManager;
 import io.github.pnoker.common.data.entity.model.EventHistoryDO;
 import io.github.pnoker.common.data.mapper.EventHistoryMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/MessageManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/MessageManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.MessageManager;
 import io.github.pnoker.common.data.entity.model.MessageDO;
 import io.github.pnoker.common.data.mapper.MessageMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyChannelBindManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyChannelBindManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.NotifyChannelBindManager;
 import io.github.pnoker.common.data.entity.model.NotifyChannelBindDO;
 import io.github.pnoker.common.data.mapper.NotifyChannelBindMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyChannelManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyChannelManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.NotifyChannelManager;
 import io.github.pnoker.common.data.entity.model.NotifyChannelDO;
 import io.github.pnoker.common.data.mapper.NotifyChannelMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyHistoryManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyHistoryManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.NotifyHistoryManager;
 import io.github.pnoker.common.data.entity.model.NotifyHistoryDO;
 import io.github.pnoker.common.data.mapper.NotifyHistoryMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/NotifyManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.NotifyManager;
 import io.github.pnoker.common.data.entity.model.NotifyDO;
 import io.github.pnoker.common.data.mapper.NotifyMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/PointCommandHistoryManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/PointCommandHistoryManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.PointCommandHistoryManager;
 import io.github.pnoker.common.data.entity.model.PointCommandHistoryDO;
 import io.github.pnoker.common.data.mapper.PointCommandHistoryMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/PointValueManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/PointValueManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.PointValueManager;
 import io.github.pnoker.common.data.entity.model.PointValueDO;
 import io.github.pnoker.common.data.mapper.PointValueMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/RuleManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/RuleManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.RuleManager;
 import io.github.pnoker.common.data.entity.model.RuleDO;
 import io.github.pnoker.common.data.mapper.RuleMapper;

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/RuleStateManagerImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/dal/impl/RuleStateManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.data.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.data.dal.RuleStateManager;
 import io.github.pnoker.common.data.entity.model.RuleStateDO;
 import io.github.pnoker.common.data.mapper.RuleStateMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandAttributeConfigManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandAttributeConfigManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.CommandAttributeConfigDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandAttributeManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandAttributeManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.CommandAttributeDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.CommandDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandParamManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/CommandParamManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.CommandParamDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DeviceManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DeviceManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.DeviceDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DriverAttributeConfigManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DriverAttributeConfigManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.DriverAttributeConfigDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DriverAttributeManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DriverAttributeManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.DriverAttributeDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DriverManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/DriverManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.DriverDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventAttributeConfigManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventAttributeConfigManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.EventAttributeConfigDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventAttributeManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventAttributeManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.EventAttributeDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.EventDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventParamManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/EventParamManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.EventParamDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointAttributeConfigManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointAttributeConfigManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.PointAttributeConfigDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointAttributeManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointAttributeManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.PointAttributeDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointDataVolumeHistoryManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointDataVolumeHistoryManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.PointDataVolumeHistoryDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/PointManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.PointDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/ProfileManager.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/ProfileManager.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal;
 
-import com.baomidou.mybatisplus.extension.service.IService;
+import com.baomidou.mybatisplus.spring.service.IService;
 import io.github.pnoker.common.manager.entity.model.ProfileDO;
 
 /**

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandAttributeConfigManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandAttributeConfigManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.CommandAttributeConfigManager;
 import io.github.pnoker.common.manager.entity.model.CommandAttributeConfigDO;
 import io.github.pnoker.common.manager.mapper.CommandAttributeConfigMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandAttributeManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandAttributeManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.CommandAttributeManager;
 import io.github.pnoker.common.manager.entity.model.CommandAttributeDO;
 import io.github.pnoker.common.manager.mapper.CommandAttributeMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.CommandManager;
 import io.github.pnoker.common.manager.entity.model.CommandDO;
 import io.github.pnoker.common.manager.mapper.CommandMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandParamManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/CommandParamManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.CommandParamManager;
 import io.github.pnoker.common.manager.entity.model.CommandParamDO;
 import io.github.pnoker.common.manager.mapper.CommandParamMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DeviceManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DeviceManagerImpl.java
@@ -19,7 +19,7 @@ package io.github.pnoker.common.manager.dal.impl;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.constant.common.QueryWrapperConstant;
 import io.github.pnoker.common.exception.AddException;
 import io.github.pnoker.common.exception.DuplicateException;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DriverAttributeConfigManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DriverAttributeConfigManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.DriverAttributeConfigManager;
 import io.github.pnoker.common.manager.entity.model.DriverAttributeConfigDO;
 import io.github.pnoker.common.manager.mapper.DriverAttributeConfigMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DriverAttributeManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DriverAttributeManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.DriverAttributeManager;
 import io.github.pnoker.common.manager.entity.model.DriverAttributeDO;
 import io.github.pnoker.common.manager.mapper.DriverAttributeMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DriverManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/DriverManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.DriverManager;
 import io.github.pnoker.common.manager.entity.model.DriverDO;
 import io.github.pnoker.common.manager.mapper.DriverMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventAttributeConfigManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventAttributeConfigManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.EventAttributeConfigManager;
 import io.github.pnoker.common.manager.entity.model.EventAttributeConfigDO;
 import io.github.pnoker.common.manager.mapper.EventAttributeConfigMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventAttributeManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventAttributeManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.EventAttributeManager;
 import io.github.pnoker.common.manager.entity.model.EventAttributeDO;
 import io.github.pnoker.common.manager.mapper.EventAttributeMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.EventManager;
 import io.github.pnoker.common.manager.entity.model.EventDO;
 import io.github.pnoker.common.manager.mapper.EventMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventParamManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/EventParamManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.EventParamManager;
 import io.github.pnoker.common.manager.entity.model.EventParamDO;
 import io.github.pnoker.common.manager.mapper.EventParamMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointAttributeConfigManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointAttributeConfigManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.PointAttributeConfigManager;
 import io.github.pnoker.common.manager.entity.model.PointAttributeConfigDO;
 import io.github.pnoker.common.manager.mapper.PointAttributeConfigMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointAttributeManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointAttributeManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.PointAttributeManager;
 import io.github.pnoker.common.manager.entity.model.PointAttributeDO;
 import io.github.pnoker.common.manager.mapper.PointAttributeMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointDataVolumeHistoryManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointDataVolumeHistoryManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.PointDataVolumeHistoryManager;
 import io.github.pnoker.common.manager.entity.model.PointDataVolumeHistoryDO;
 import io.github.pnoker.common.manager.mapper.PointDataVolumeHistoryMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/PointManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.PointManager;
 import io.github.pnoker.common.manager.entity.model.PointDO;
 import io.github.pnoker.common.manager.mapper.PointMapper;

--- a/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/ProfileManagerImpl.java
+++ b/dc3-common/dc3-common-manager/src/main/java/io/github/pnoker/common/manager/dal/impl/ProfileManagerImpl.java
@@ -17,7 +17,7 @@
 
 package io.github.pnoker.common.manager.dal.impl;
 
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.spring.service.impl.ServiceImpl;
 import io.github.pnoker.common.manager.dal.ProfileManager;
 import io.github.pnoker.common.manager.entity.model.ProfileDO;
 import io.github.pnoker.common.manager.mapper.ProfileMapper;

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <paho.mqttv3.version>1.2.5</paho.mqttv3.version>
 
         <!-- Data access -->
-        <mybatis.plus.version>3.5.16</mybatis.plus.version>
+        <mybatis.plus.version>3.5.17</mybatis.plus.version>
         <mybatis.plus.dynamic.version>4.5.0</mybatis.plus.dynamic.version>
         
         <!-- Embedded database for the driver local point-value buffer -->


### PR DESCRIPTION
手动适配 mybatis-plus 3.5.17 的 split-package 迁移(#7027):仅 `IService`/`ServiceImpl` 从 `extension.service` 移到 `spring.service`(已用 3.5.17 jar 核实),其余 extension 类(Page/JacksonTypeHandler/chain wrappers/Db/interceptors)未迁移。改 112 处 import。取代 dependabot #141。本地 mvn compile 全绿(除 bacnet4j 驱动因本地 mirror 缓存缺失,CI 可正常下载)。