### PR TITLE
ci(backend): run backend CI on every PR (fix npm PR BLOCKED)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -7,8 +7,9 @@ on:
       - dc3-web/**
   pull_request:
     branches: [ develop, main ]
-    paths-ignore:
-      - dc3-web/**
+    # no paths-ignore here: required checks (compile/Unit/Integration/coverage)
+    # must run on every PR, including dc3-web-only ones (they compile the
+    # unchanged backend — fast with the maven cache — so the PR isn't left BLOCKED)
 
 permissions:
   contents: read


### PR DESCRIPTION
## 问题
`ci-backend.yml` 的 `pull_request` 有 `paths-ignore: dc3-web/**`,只改 dc3-web 的 dependabot PR 不触发后端 CI,但 `compile` 等是 required → 永远 3/4 缺 compile 而 BLOCKED,只能 `--admin` 绕过(本次 #137-140 如此)。

## 修复
去掉 `pull_request` 的 paths-ignore,每个 PR 都跑后端 CI(required 满足)。`push` 保留 paths-ignore(dc3-web-only push 仍跳过,PR 阶段已验证)。npm PR 编译未变更的后端(maven cache 快),换不再 BLOCKED。

## 关联
根因见 #150/#151;治本记录见 memory compile-paths-filter-gap。