### PR TITLE
build(deps): bump californium 4.0.0-M3 → 4.0.0-M6 + adapt CoapExchange

### DIFF
--- a/dc3-driver/dc3-driver-coap/src/main/java/io/github/pnoker/driver/coap/server/resource/DataResource.java
+++ b/dc3-driver/dc3-driver-coap/src/main/java/io/github/pnoker/driver/coap/server/resource/DataResource.java
@@ -22,7 +22,7 @@ import io.github.pnoker.driver.coap.service.CoapReceiveService;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP;
-import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.core.CoapExchange;
 
 /**
  * CoAP Data Resource

--- a/dc3-driver/pom.xml
+++ b/dc3-driver/pom.xml
@@ -41,7 +41,7 @@
         <milo.version>0.6.16</milo.version>
 
         <!-- CoAP -->
-        <californium.version>4.0.0-M3</californium.version>
+        <californium.version>4.0.0-M6</californium.version>
 
         <!-- LwM2M -->
         <leshan.version>2.0.0-M14</leshan.version>


### PR DESCRIPTION
手动适配 californium 4.0.0-M6 的 CoapExchange 迁包(core.server.resources→core,已 compile 核实)。dc3-driver-coap 只用核心 CoAP API,不碰 DTLS/observe/MessageObserver(M3→M6 breaking 重灾区),故仅改 1 处 import。取代 dependabot #81。收益:M4-M6 bugfix + Java 21 虚拟线程 + RFC 7252 合规;4.0.0 GA 无时间表。本地 mvn compile dc3-driver-coap 通过。