### PR TITLE
fix(security): sanitize agentic assistant HTML with DOMPurify

### DIFF
--- a/dc3-web/package.json
+++ b/dc3-web/package.json
@@ -58,6 +58,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "axios": "^1.18.1",
     "dayjs": "^1.11.21",
+    "dompurify": "^3.4.12",
     "element-plus": "^2.14.3",
     "highlight.js": "^11.11.1",
     "js-base64": "^3.9.1",

--- a/dc3-web/pnpm-lock.yaml
+++ b/dc3-web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
+      dompurify:
+        specifier: ^3.4.12
+        version: 3.4.12
       element-plus:
         specifier: ^2.14.3
         version: 2.14.3(vue@3.5.40(typescript@6.0.3))
@@ -731,6 +734,9 @@ packages:
   '@types/nprogress@0.2.3':
     resolution: {integrity: sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
@@ -1342,6 +1348,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3214,6 +3223,9 @@ snapshots:
 
   '@types/nprogress@0.2.3': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/web-bluetooth@0.0.21': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
@@ -3929,6 +3941,10 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/dc3-web/src/components/agentic/RenderedAssistantMessage.vue
+++ b/dc3-web/src/components/agentic/RenderedAssistantMessage.vue
@@ -27,6 +27,7 @@
 
 <script lang="ts" setup>
 import {marked} from 'marked';
+import DOMPurify from 'dompurify';
 import {computed} from 'vue';
 import ChartBlock from './ChartBlock.vue';
 import {parseAssistantContent} from './assistantContent';
@@ -37,15 +38,11 @@ const props = defineProps<{ content: string; charts?: AgenticVisualizationSpec[]
 const segments = computed(() => parseAssistantContent(props.content).segments);
 const charts = computed(() => props.charts || []);
 
+// Assistant content is model output rendered via v-html, so it must be sanitized with
+// DOMPurify (script blocks, on* handlers, javascript:, data:/vbscript: schemes, mutation
+// XSS). The previous hand-rolled regex sanitizer missed several of these (CodeQL
+// js/bad-tag-filter, incomplete-*, url-scheme-check).
 const renderMarkdown = (text: string) => {
-  return sanitizeHtml(String(marked.parse(text)));
-};
-
-const sanitizeHtml = (html: string) => {
-  return html
-    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
-    .replace(/\son\w+="[^"]*"/gi, '')
-    .replace(/\son\w+='[^']*'/gi, '')
-    .replace(/javascript:/gi, '');
+  return DOMPurify.sanitize(String(marked.parse(text)), {USE_PROFILES: {html: true}});
 };
 </script>


### PR DESCRIPTION
用 DOMPurify 替换手写正则 sanitizer(被 CodeQL 标 5 个 high XSS:bad-tag-filter、incomplete-multi-character-sanitization ×2、incomplete-url-scheme-check)。AI assistant 内容经 v-html 渲染,必须用成熟库净化(script/on*/javascript:/data:/vbscript:/mutation XSS 全覆盖)。type-check 通过。修复 CodeQL #2146-2150。