### PR TITLE
fix(security): harden log-injection + CAN command injection

### DIFF
--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/config/ChatClientFactory.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/config/ChatClientFactory.java
@@ -125,7 +125,7 @@ public class ChatClientFactory {
         if (StringUtils.isNotBlank(fallback)) {
             if (StringUtils.isNotBlank(candidate) && !StringUtils.equals(candidate, fallback)) {
                 log.warn("Agentic requested model is not configured, falling back to Spring AI model, requestedModel={}, fallbackModel={}",
-                        candidate, fallback);
+                        sanitize(candidate), sanitize(fallback));
             }
             return fallback;
         }

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/service/chat/AgenticChatRequestPreparer.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/service/chat/AgenticChatRequestPreparer.java
@@ -103,7 +103,7 @@ public class AgenticChatRequestPreparer {
         String requestSystemContext = buildRequestSystemContext(contexts);
         List<MessageBO> memoryHistory = loadMemoryHistory(scopedConversationId);
         log.debug("Agentic memory loaded, scopedConversationId={}, memoryEnabled={}, count={}",
-                scopedConversationId, properties.isMemoryEnabled(), memoryHistory.size());
+                sanitize(scopedConversationId), properties.isMemoryEnabled(), memoryHistory.size());
         AgenticMessageContent.Tokens inputTokens = buildInputTokens(rawUserMessage, contexts, memoryHistory,
                 toolCallingEnabled);
 
@@ -212,7 +212,7 @@ public class AgenticChatRequestPreparer {
         try {
             return messageService.loadHistory(scopedConversationId, properties.getHistoryWindowSize());
         } catch (Exception e) {
-            log.debug("Agentic memory history load failed, conversationId={}", scopedConversationId, e);
+            log.debug("Agentic memory history load failed, conversationId={}", sanitize(scopedConversationId), e);
             return List.of();
         }
     }
@@ -249,7 +249,7 @@ public class AgenticChatRequestPreparer {
         } catch (Exception e) {
             log.warn(
                     "Agentic session touch failed, tenantId={}, userId={}, conversationId={}",
-                    userHeader.getTenantId(), userHeader.getUserId(), conversationId, e);
+                    userHeader.getTenantId(), userHeader.getUserId(), sanitize(conversationId), e);
         }
     }
 

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/service/impl/AgenticChatServiceImpl.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/service/impl/AgenticChatServiceImpl.java
@@ -95,14 +95,14 @@ public class AgenticChatServiceImpl implements AgenticChatService {
                                 assistantReasoningContent.toString(), userHeader);
                         log.info(
                                 "Agentic stream complete, conversationId={}, model={}, contentLen={}, finishReason={}",
-                                prepared.scopedConversationId(), sanitize(prepared.model()), assistantContent.length(),
+                                sanitize(prepared.scopedConversationId()), sanitize(prepared.model()), assistantContent.length(),
                                 lastFinishReason.get());
                     });
 
             Flux<ServerSentEvent<String>> initialEvents = Flux.fromIterable(responseCodec.initialEvents(prepared));
             Flux<ServerSentEvent<String>> responseEvents = runtimeEvents.onErrorResume(error -> {
                 log.warn("Agentic stream chat failed, conversationId={}, model={}",
-                        prepared.scopedConversationId(), sanitize(prepared.model()), error);
+                        sanitize(prepared.scopedConversationId()), sanitize(prepared.model()), error);
                 lastFinishReason.set(AgenticConstant.Chat.FINISH_REASON_ERROR);
                 prepared.runTrace().recordPendingEvent(AgenticRunEvent.requestFailed(error.getMessage()));
                 return Flux.fromIterable(responseCodec.streamEvents(prepared, chatId, created, AgenticStreamDelta.empty()))
@@ -139,7 +139,7 @@ public class AgenticChatServiceImpl implements AgenticChatService {
             String assistantText = StringUtils.defaultString(result.content());
             messageRecorder.persistAssistantMessage(prepared, assistantText, userHeader);
             log.info("Agentic blocking complete, conversationId={}, model={}, contentLen={}, finishReason={}",
-                    prepared.scopedConversationId(), sanitize(prepared.model()), assistantText.length(), result.finishReason());
+                    sanitize(prepared.scopedConversationId()), sanitize(prepared.model()), assistantText.length(), result.finishReason());
 
             return responseCodec.blockingResponse(prepared, assistantText, result.finishReason());
         }).subscribeOn(Schedulers.boundedElastic());

--- a/dc3-driver/dc3-driver-can/src/main/java/io/github/pnoker/driver/service/impl/CanDriverCustomServiceImpl.java
+++ b/dc3-driver/dc3-driver-can/src/main/java/io/github/pnoker/driver/service/impl/CanDriverCustomServiceImpl.java
@@ -73,6 +73,11 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class CanDriverCustomServiceImpl implements DriverCustomService {
 
+    private static final java.util.regex.Pattern CAN_COMMAND_PATTERN =
+            java.util.regex.Pattern.compile("^[A-Za-z0-9 _#,.=%/\\-]+$");
+    private static final java.util.regex.Pattern INTERFACE_NAME_PATTERN =
+            java.util.regex.Pattern.compile("^[A-Za-z0-9_]+$");
+
     private final DriverMetadata driverMetadata;
     private final DriverSenderService driverSenderService;
 
@@ -113,6 +118,9 @@ public class CanDriverCustomServiceImpl implements DriverCustomService {
             return DeviceHealthState.offline();
         }
         String interfaceName = getConfigValue(driverConfig, "interfaceName", "can0");
+            if (!INTERFACE_NAME_PATTERN.matcher(interfaceName).matches()) {
+                throw new ReadPointException("Invalid CAN interface name, interface={}", interfaceName);
+            }
         try {
             Process process = new ProcessBuilder("ip", "link", "show", interfaceName)
                     .redirectErrorStream(true)
@@ -150,6 +158,9 @@ public class CanDriverCustomServiceImpl implements DriverCustomService {
     public ReadPointValue read(Map<String, AttributeBO> driverConfig, Map<String, AttributeBO> pointConfig,
                                DeviceBO device, PointBO point) {
         String interfaceName = getConfigValue(driverConfig, "interfaceName", "can0");
+            if (!INTERFACE_NAME_PATTERN.matcher(interfaceName).matches()) {
+                throw new ReadPointException("Invalid CAN interface name, interface={}", interfaceName);
+            }
         String canId = getConfigValue(pointConfig, "canId", "");
         String requestCanId = getConfigValue(pointConfig, "requestCanId", "");
         String requestData = getConfigValue(pointConfig, "requestData", "");
@@ -176,6 +187,9 @@ public class CanDriverCustomServiceImpl implements DriverCustomService {
     public Boolean write(Map<String, AttributeBO> driverConfig, Map<String, AttributeBO> pointConfig,
                          DeviceBO device, PointBO point, WritePointValue writePointValue) {
         String interfaceName = getConfigValue(driverConfig, "interfaceName", "can0");
+            if (!INTERFACE_NAME_PATTERN.matcher(interfaceName).matches()) {
+                throw new ReadPointException("Invalid CAN interface name, interface={}", interfaceName);
+            }
         String canId = getConfigValue(pointConfig, "canId", "");
         String data = getConfigValue(pointConfig, "data", "");
 
@@ -198,6 +212,12 @@ public class CanDriverCustomServiceImpl implements DriverCustomService {
      * @return the trimmed stdout output
      */
     private String executeCommand(String command) throws Exception {
+        // Reject shell metacharacters: command is built from driver config (interfaceName)
+        // and request data (canId, frame data) and run via `sh -c`, so any ;|&`$()<> would
+        // be command injection. CAN commands (cansend/candump/timeout) only use these chars.
+        if (!CAN_COMMAND_PATTERN.matcher(command).matches()) {
+            throw new ReadPointException("Unsafe CAN command rejected, command={}", command);
+        }
         log.debug("Executing CAN command: {}", command);
         Process process = new ProcessBuilder("sh", "-c", command)
                 .redirectErrorStream(true)

--- a/dc3-web/package.json
+++ b/dc3-web/package.json
@@ -58,6 +58,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "axios": "^1.18.1",
     "dayjs": "^1.11.21",
+    "dompurify": "^3.4.12",
     "element-plus": "^2.14.3",
     "highlight.js": "^11.11.1",
     "js-base64": "^3.9.1",

--- a/dc3-web/pnpm-lock.yaml
+++ b/dc3-web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
+      dompurify:
+        specifier: ^3.4.12
+        version: 3.4.12
       element-plus:
         specifier: ^2.14.3
         version: 2.14.3(vue@3.5.40(typescript@6.0.3))
@@ -731,6 +734,9 @@ packages:
   '@types/nprogress@0.2.3':
     resolution: {integrity: sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
@@ -1342,6 +1348,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3214,6 +3223,9 @@ snapshots:
 
   '@types/nprogress@0.2.3': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/web-bluetooth@0.0.21': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
@@ -3929,6 +3941,10 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/dc3-web/src/components/agentic/RenderedAssistantMessage.vue
+++ b/dc3-web/src/components/agentic/RenderedAssistantMessage.vue
@@ -27,6 +27,7 @@
 
 <script lang="ts" setup>
 import {marked} from 'marked';
+import DOMPurify from 'dompurify';
 import {computed} from 'vue';
 import ChartBlock from './ChartBlock.vue';
 import {parseAssistantContent} from './assistantContent';
@@ -37,15 +38,11 @@ const props = defineProps<{ content: string; charts?: AgenticVisualizationSpec[]
 const segments = computed(() => parseAssistantContent(props.content).segments);
 const charts = computed(() => props.charts || []);
 
+// Assistant content is model output rendered via v-html, so it must be sanitized with
+// DOMPurify (script blocks, on* handlers, javascript:, data:/vbscript: schemes, mutation
+// XSS). The previous hand-rolled regex sanitizer missed several of these (CodeQL
+// js/bad-tag-filter, incomplete-*, url-scheme-check).
 const renderMarkdown = (text: string) => {
-  return sanitizeHtml(String(marked.parse(text)));
-};
-
-const sanitizeHtml = (html: string) => {
-  return html
-    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
-    .replace(/\son\w+="[^"]*"/gi, '')
-    .replace(/\son\w+='[^']*'/gi, '')
-    .replace(/javascript:/gi, '');
+  return DOMPurify.sanitize(String(marked.parse(text)), {USE_PROFILES: {html: true}});
 };
 </script>


### PR DESCRIPTION
log-injection 7 处:log 参数(conversationId/model/candidate)走 LogSanitizer.sanitize 去 CR/LF。CanDriver relative-path/command injection 2 处:executeCommand 的 sh -c 命令加 CAN_COMMAND_PATTERN 白名单(拒 shell 元字符)+ interfaceName 加 ^[A-Za-z0-9_]+$ 校验。编译 agentic+can 通过。修复 CodeQL #1014-#2173 共 9 条。