### PR TITLE
fix(docs): restore 5-pillar nav and fix version switcher position

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,15 +36,19 @@ type Pillar = {
     groups: ReadonlyArray<Group>
 }
 
-// Pillar order: 总览 → 架构 → 驱动 → AI → 基础 → 开发 → 运维 (after nav 首页)
+// Pillar order: 架构 → 驱动 → AI → 基础 → 开发 (after nav 首页)
+// Overview is absorbed into Architecture (project-overview group); Operations is
+// absorbed into Develop; AI stands alone — the consolidated 5-pillar design.
 const PILLARS: ReadonlyArray<Pillar> = [
-    {   // ① 总览
-        navKey: 'pillar.overview', landing: 'introduction',
-        paths: ['introduction', 'quickstart'], activeMatch: '^/(zh|en)/(introduction|quickstart)/',
+    {   // ① 架构(吸收总览:introduction 系列 + quickstart 概念在此安家)
+        navKey: 'pillar.architecture', landing: 'architecture',
+        paths: ['architecture', 'modules', 'introduction'],
+        activeMatch: '^/(zh|en)/(architecture|modules|introduction)/',
         groups: [
+            {key: '', items: [['architecture']]},
             {
-                key: '',
-                items: [['introduction'], ['introduction/concepts'], ['introduction/paths']]
+                key: 'group.project-overview',
+                items: [['introduction'], ['introduction/concepts'], ['introduction/paths'], ['introduction/concepts/tenant']]
             },
             {
                 key: 'group.objects-data',
@@ -52,26 +56,18 @@ const PILLARS: ReadonlyArray<Pillar> = [
             },
             {
                 key: 'group.capabilities-boundaries',
-                items: [['introduction/concepts/command'], ['introduction/concepts/event'], ['introduction/concepts/attribute-config'], ['introduction/concepts/tenant']]
+                items: [['introduction/concepts/command'], ['introduction/concepts/event'], ['introduction/concepts/attribute-config']]
             },
-            {key: 'group.quickstart', items: [['quickstart'], ['quickstart/environment'], ['quickstart/first-device']]},
-            {key: 'group.appendix', items: [['introduction/glossary'], ['introduction/license']]}
-        ]
-    },
-    {   // ② 架构
-        navKey: 'pillar.architecture', landing: 'architecture',
-        paths: ['architecture', 'modules'], activeMatch: '^/(zh|en)/(architecture|modules)/',
-        groups: [
-            {key: '', items: [['architecture']]},
             {key: 'group.services-collab', items: [['architecture/services'], ['architecture/facade-modes']]},
             {
                 key: 'group.pipelines-model',
                 items: [['architecture/data-plane'], ['architecture/command-plane'], ['architecture/auth-rbac'], ['architecture/domain-model']]
             },
-            {key: 'group.modules', items: [['architecture/modules'], ['modules']]}
+            {key: 'group.modules', items: [['architecture/modules'], ['modules']]},
+            {key: 'group.appendix', items: [['introduction/glossary'], ['introduction/license']]}
         ]
     },
-    {   // ③ 驱动
+    {   // ② 驱动
         navKey: 'pillar.drivers', landing: 'drivers',
         paths: ['drivers', 'operation/device-onboarding'],
         activeMatch: '^/(zh|en)/(drivers/|operation/device-onboarding)',
@@ -98,7 +94,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
             {key: 'group.appendix-drivers', items: [['drivers/matrix']]}
         ]
     },
-    {   // ④ AI
+    {   // ③ AI(从开发提取为独立顶级 pillar)
         navKey: 'pillar.ai',
         landing: 'ai',
         paths: ['ai'],
@@ -108,7 +104,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
             {key: 'group.ai-integration', items: [['ai/agentic'], ['ai/mcp'], ['ai/spring-ai-deep-dive']]}
         ]
     },
-    {   // ⑤ 基础
+    {   // ④ 基础
         navKey: 'pillar.foundations', landing: 'foundations',
         paths: ['foundations'], activeMatch: '^/(zh|en)/foundations/',
         groups: [
@@ -120,29 +116,24 @@ const PILLARS: ReadonlyArray<Pillar> = [
             {key: 'group.security', items: [['foundations/security']]}
         ]
     },
-    {   // ⑥ 开发
+    {   // ⑤ 开发(吸收运维:quickstart → 部署运维 → 开发 → 前端 → 自动化 → 运营)
         navKey: 'pillar.develop',
         landing: 'development',
-        paths: ['development', 'frontend', 'automation'],
-        activeMatch: '^/(zh|en)/(development|frontend|automation)/',
+        paths: ['development', 'frontend', 'automation', 'quickstart', 'operation', 'guide'],
+        activeMatch: '^/(zh|en)/(development|frontend|automation|quickstart|operation|guide)/',
         groups: [
+            {key: 'group.quickstart', items: [['quickstart'], ['quickstart/environment'], ['quickstart/first-device']]},
+            {
+                key: 'group.deploy-ops',
+                items: [['guide/usage'], ['guide/observability'], ['guide/logging'], ['guide/troubleshooting']]
+            },
             {
                 key: 'group.development',
                 items: [['development'], ['development/driver-authoring'], ['development/api-documentation'], ['development/technology-stack'], ['development/testing'], ['development/changelog']]
             },
             {key: 'group.frontend', items: [['frontend'], ['frontend/test-debugging']]},
-            {key: 'group.automation', items: [['automation/cli']]}
-        ]
-    },
-    {   // ⑦ 运维
-        navKey: 'pillar.operations', landing: 'operation',
-        paths: ['operation', 'guide'], activeMatch: '^/(zh|en)/(operation|guide)/',
-        groups: [
-            {key: 'group.operations', items: [['operation'], ['operation/data-commands'], ['operation/alarms']]},
-            {
-                key: 'group.deploy-ops',
-                items: [['guide/usage'], ['guide/observability'], ['guide/logging'], ['guide/troubleshooting']]
-            }
+            {key: 'group.automation', items: [['automation/cli']]},
+            {key: 'group.operations', items: [['operation'], ['operation/data-commands'], ['operation/alarms']]}
         ]
     }
 ]

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -127,6 +127,27 @@ body {
     }
 }
 
+/* Order the right-side toolbar so the version switcher sits between the
+   language switcher and the appearance (theme) toggle. The version switcher
+   is injected last via the nav-bar-content-after slot (see theme/index.ts);
+   without this it renders after the social links, at the far right. Desktop
+   only — below this breakpoint the translations/appearance controls collapse
+   into the hamburger extra-menu and this reordering does not apply. */
+@media (min-width: 960px) {
+    .VPNavBar .content .content-body .VPNavBarTranslations {
+        order: 6;
+    }
+    .VPNavBar .content .content-body .dc3-version-switcher {
+        order: 7;
+    }
+    .VPNavBar .content .content-body .VPNavBarAppearance {
+        order: 8;
+    }
+    .VPNavBar .content .content-body .VPNavBarSocialLinks {
+        order: 9;
+    }
+}
+
 .VPNavBarTitle .title {
     font-weight: 720;
     letter-spacing: 0;

--- a/docs/locales/en.json
+++ b/docs/locales/en.json
@@ -1,7 +1,7 @@
 {
-  "pillar.ai": "AI",
   "pillar.architecture": "Architecture",
   "pillar.drivers": "Drivers",
+  "pillar.ai": "AI",
   "pillar.foundations": "Foundations",
   "pillar.develop": "Develop",
   "community": "Community",

--- a/docs/locales/zh.json
+++ b/docs/locales/zh.json
@@ -1,7 +1,7 @@
 {
-  "pillar.ai": "AI",
   "pillar.architecture": "架构",
   "pillar.drivers": "驱动",
+  "pillar.ai": "AI",
   "pillar.foundations": "基础",
   "pillar.develop": "开发",
   "community": "社区",


### PR DESCRIPTION
## 背景

合并 `6a4bef72c`(promote develop to main)在 fuse 文档导航时偏向了 develop 的扁平结构,引发三个问题,本 PR 一并修复。

## 改动

### 1. 恢复 5-pillar 合并版导航(15341a560)
恢复 `261af5721` 的合并设计(被上述合并拆散):
- **架构** 吸收总览(introduction → 项目总览组)
- **开发** 吸收运维(运营组 + 部署与运维组,quickstart 一并归入)
- **AI** 独立成项

菜单恢复为:**首页 · 架构 · 驱动 · AI · 基础 · 开发 · 社区**

### 2. 修复 Header 英文回退
5-pillar 版不再有 overview/operations 顶级项,根除 header 里 `overview`/`operations` 英文回退;同时删除不再使用的 `pillar.overview`/`pillar.operations` i18n key。

### 3. 版本切换器位置(fe5a67dcd)
版本切换器原在导航栏最右(社交链接后),现用 flex `order` 置于语言切换与主题切换之间(桌面 ≥960px)。

## 验证
- `pnpm docs:build` 通过
- SSR HTML 确认 nav 5 项、sidebar 分组齐全、无英文回退
- 页面完整性:恢复前后均 90 个页面,零丢失;i18n / group key 零缺失

🤖 Generated with [Claude Code](https://claude.com/claude-code)