### PR TITLE
build(deps): bump pnpm/action-setup to v6.0.10

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
         with:
           package_json_file: dc3-web/package.json
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
         with:
           package_json_file: dc3-web/package.json
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
         with:
           package_json_file: docs/package.json
           run_install: false


### PR DESCRIPTION
`pnpm/action-setup` 此前 pin 在 Node.js 20 runtime(已废弃,GitHub 强制 Node 24 并告警)。升级到 v6.0.10(commit `0977fd9`),原生跑 Node 24,消除 deprecation 警告。

涉及 `docs.yml`(1 处)+ `ci-web.yml`(2 处),共 3 处。

合并后 `docs.yml` 部署日志不再有 `Node.js 20 is deprecated` 警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)