### PR TITLE
chore(docs): sync docs from main to develop (5-pillar)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,15 +36,19 @@ type Pillar = {
     groups: ReadonlyArray<Group>
 }
 
-// Pillar order: 总览 → 架构 → 驱动 → AI → 基础 → 开发 → 运维 (after nav 首页)
+// Pillar order: 架构 → 驱动 → AI → 基础 → 开发 (after nav 首页)
+// Overview is absorbed into Architecture (project-overview group); Operations is
+// absorbed into Develop; AI stands alone — the consolidated 5-pillar design.
 const PILLARS: ReadonlyArray<Pillar> = [
-    {   // ① 总览
-        navKey: 'pillar.overview', landing: 'introduction',
-        paths: ['introduction', 'quickstart'], activeMatch: '^/(zh|en)/(introduction|quickstart)/',
+    {   // ① 架构(吸收总览:introduction 系列 + quickstart 概念在此安家)
+        navKey: 'pillar.architecture', landing: 'architecture',
+        paths: ['architecture', 'modules', 'introduction'],
+        activeMatch: '^/(zh|en)/(architecture|modules|introduction)/',
         groups: [
+            {key: '', items: [['architecture']]},
             {
-                key: '',
-                items: [['introduction'], ['introduction/concepts'], ['introduction/paths']]
+                key: 'group.project-overview',
+                items: [['introduction'], ['introduction/concepts'], ['introduction/paths'], ['introduction/concepts/tenant']]
             },
             {
                 key: 'group.objects-data',
@@ -52,26 +56,18 @@ const PILLARS: ReadonlyArray<Pillar> = [
             },
             {
                 key: 'group.capabilities-boundaries',
-                items: [['introduction/concepts/command'], ['introduction/concepts/event'], ['introduction/concepts/attribute-config'], ['introduction/concepts/tenant']]
+                items: [['introduction/concepts/command'], ['introduction/concepts/event'], ['introduction/concepts/attribute-config']]
             },
-            {key: 'group.quickstart', items: [['quickstart'], ['quickstart/environment'], ['quickstart/first-device']]},
-            {key: 'group.appendix', items: [['introduction/glossary'], ['introduction/license']]}
-        ]
-    },
-    {   // ② 架构
-        navKey: 'pillar.architecture', landing: 'architecture',
-        paths: ['architecture', 'modules'], activeMatch: '^/(zh|en)/(architecture|modules)/',
-        groups: [
-            {key: '', items: [['architecture']]},
             {key: 'group.services-collab', items: [['architecture/services'], ['architecture/facade-modes']]},
             {
                 key: 'group.pipelines-model',
                 items: [['architecture/data-plane'], ['architecture/command-plane'], ['architecture/auth-rbac'], ['architecture/domain-model']]
             },
-            {key: 'group.modules', items: [['architecture/modules'], ['modules']]}
+            {key: 'group.modules', items: [['architecture/modules'], ['modules']]},
+            {key: 'group.appendix', items: [['introduction/glossary'], ['introduction/license']]}
         ]
     },
-    {   // ③ 驱动
+    {   // ② 驱动
         navKey: 'pillar.drivers', landing: 'drivers',
         paths: ['drivers', 'operation/device-onboarding'],
         activeMatch: '^/(zh|en)/(drivers/|operation/device-onboarding)',
@@ -98,7 +94,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
             {key: 'group.appendix-drivers', items: [['drivers/matrix']]}
         ]
     },
-    {   // ④ AI
+    {   // ③ AI(从开发提取为独立顶级 pillar)
         navKey: 'pillar.ai',
         landing: 'ai',
         paths: ['ai'],
@@ -108,7 +104,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
             {key: 'group.ai-integration', items: [['ai/agentic'], ['ai/mcp'], ['ai/spring-ai-deep-dive']]}
         ]
     },
-    {   // ⑤ 基础
+    {   // ④ 基础
         navKey: 'pillar.foundations', landing: 'foundations',
         paths: ['foundations'], activeMatch: '^/(zh|en)/foundations/',
         groups: [
@@ -120,29 +116,24 @@ const PILLARS: ReadonlyArray<Pillar> = [
             {key: 'group.security', items: [['foundations/security']]}
         ]
     },
-    {   // ⑥ 开发
+    {   // ⑤ 开发(吸收运维:quickstart → 部署运维 → 开发 → 前端 → 自动化 → 运营)
         navKey: 'pillar.develop',
         landing: 'development',
-        paths: ['development', 'frontend', 'automation'],
-        activeMatch: '^/(zh|en)/(development|frontend|automation)/',
+        paths: ['development', 'frontend', 'automation', 'quickstart', 'operation', 'guide'],
+        activeMatch: '^/(zh|en)/(development|frontend|automation|quickstart|operation|guide)/',
         groups: [
+            {key: 'group.quickstart', items: [['quickstart'], ['quickstart/environment'], ['quickstart/first-device']]},
+            {
+                key: 'group.deploy-ops',
+                items: [['guide/usage'], ['guide/observability'], ['guide/logging'], ['guide/troubleshooting']]
+            },
             {
                 key: 'group.development',
                 items: [['development'], ['development/driver-authoring'], ['development/api-documentation'], ['development/technology-stack'], ['development/testing'], ['development/changelog']]
             },
             {key: 'group.frontend', items: [['frontend'], ['frontend/test-debugging']]},
-            {key: 'group.automation', items: [['automation/cli']]}
-        ]
-    },
-    {   // ⑦ 运维
-        navKey: 'pillar.operations', landing: 'operation',
-        paths: ['operation', 'guide'], activeMatch: '^/(zh|en)/(operation|guide)/',
-        groups: [
-            {key: 'group.operations', items: [['operation'], ['operation/data-commands'], ['operation/alarms']]},
-            {
-                key: 'group.deploy-ops',
-                items: [['guide/usage'], ['guide/observability'], ['guide/logging'], ['guide/troubleshooting']]
-            }
+            {key: 'group.automation', items: [['automation/cli']]},
+            {key: 'group.operations', items: [['operation'], ['operation/data-commands'], ['operation/alarms']]}
         ]
     }
 ]

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -127,6 +127,27 @@ body {
     }
 }
 
+/* Order the right-side toolbar so the version switcher sits between the
+   language switcher and the appearance (theme) toggle. The version switcher
+   is injected last via the nav-bar-content-after slot (see theme/index.ts);
+   without this it renders after the social links, at the far right. Desktop
+   only — below this breakpoint the translations/appearance controls collapse
+   into the hamburger extra-menu and this reordering does not apply. */
+@media (min-width: 960px) {
+    .VPNavBar .content .content-body .VPNavBarTranslations {
+        order: 6;
+    }
+    .VPNavBar .content .content-body .dc3-version-switcher {
+        order: 7;
+    }
+    .VPNavBar .content .content-body .VPNavBarAppearance {
+        order: 8;
+    }
+    .VPNavBar .content .content-body .VPNavBarSocialLinks {
+        order: 9;
+    }
+}
+
 .VPNavBarTitle .title {
     font-weight: 720;
     letter-spacing: 0;

--- a/docs/locales/en.json
+++ b/docs/locales/en.json
@@ -1,7 +1,7 @@
 {
-  "pillar.ai": "AI",
   "pillar.architecture": "Architecture",
   "pillar.drivers": "Drivers",
+  "pillar.ai": "AI",
   "pillar.foundations": "Foundations",
   "pillar.develop": "Develop",
   "community": "Community",

--- a/docs/locales/zh.json
+++ b/docs/locales/zh.json
@@ -1,7 +1,7 @@
 {
-  "pillar.ai": "AI",
   "pillar.architecture": "架构",
   "pillar.drivers": "驱动",
+  "pillar.ai": "AI",
   "pillar.foundations": "基础",
   "pillar.develop": "开发",
   "community": "社区",


### PR DESCRIPTION
## 背景
develop 的 `docs/` 与 main 分叉:develop 仍是过时的 7-pillar,且 `style.css` 落后 main 21 行(缺 navBar 工具栏 order)。两点 diff 调查显示 develop 在 docs/ 下**无任何独有改进**,真实分叉仅 4 个文件。

## 改动
将 develop 的整个 `docs/` 同步为 main 版本:
- `config.mts`:7-pillar → 5-pillar(总览并入架构、运维并入开发、AI 独立)
- `style.css`:补回 21 行 navBar 工具栏 order(版本切换器位置)
- `zh.json` / `en.json`:key 顺序统一(功能等价)

顺带修复:develop 的 config 引用 `pillar.overview`/`pillar.operations` 但 locales 已删,导致导航显示翻译缺失占位符——采用 main 版本后消除。

## 验证
- `pnpm docs:build` 通过
- nav = 5-pillar(首页·架构·驱动·AI·基础·开发·社区),无英文回退
- 无 develop 独有 docs 内容丢失(两点 diff 仅 4 文件,均为 main 侧改进)

## 不在范围
非 `docs/` 的分叉(action 升级 #171、security 等)不统一,不影响 docs 站点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)