### PR TITLE
build(deps): bump pnpm/action-setup to v6.0.10 on develop

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
         with:
           package_json_file: dc3-web/package.json
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
         with:
           package_json_file: dc3-web/package.json
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
         with:
           package_json_file: docs/package.json
           run_install: false


### PR DESCRIPTION
## 背景
#171 已把 main 的 `pnpm/action-setup` 升级到 v6.0.10(Node 24),消除 Node 20 deprecation 警告。develop 仍 pin 旧版(`b906aff`,Node 20),develop 自己的 CI 里有同样的警告。

## 改动
cherry-pick #171(`7c76f19c`)到 develop:
- `docs.yml`(1 处)+ `ci-web.yml`(2 处):`pnpm/action-setup` → v6.0.10(`0977fd9`)

> docs 只从 main 部署,本次仅为让 develop 的 CI 也无 Node 20 警告、保持两条线 workflow 一致。

## 验证
cherry-pick 干净 apply(3 处 hash 替换),无冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)