### PR TITLE
fix(api): dc3-api contract overhaul (auth JWT, history, presence, decision enum)

### DIFF
--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
@@ -170,10 +170,19 @@ message GrpcRMcpToolAuthorizeDTO {
   GrpcMcpToolAuthorizeDTO data = 2;
 }
 
+// Tool call authorization decision values. Names match the auth-side
+// string literals so the Java string <-> enum mapping is a direct valueOf.
+enum GrpcMcpDecision {
+  MCP_DECISION_UNSPECIFIED = 0;
+  AUTHORIZED = 1;
+  CONFIRM_REQUIRED = 2;
+  REJECTED = 3;
+}
+
 // Tool call authorization decision.
 message GrpcMcpToolAuthorizeDTO {
-  // Decision: AUTHORIZED / CONFIRM_REQUIRED / REJECTED.
-  string decision = 1;
+  // Authorization decision.
+  GrpcMcpDecision decision = 1;
   // Confirmation ticket ID issued when decision is CONFIRM_REQUIRED.
   string confirm_id = 2;
   // Human readable reason or confirmation prompt.

--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
@@ -61,7 +61,7 @@ message GrpcRMcpIntrospectDTO {
 
 // Token introspection result.
 message GrpcMcpIntrospectDTO {
-  bool active = 1;
+  optional bool active = 1;
   string iss = 2;
   repeated string aud = 3;
   string sub = 4;

--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/tenant.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/tenant.proto
@@ -60,6 +60,6 @@ message GrpcTenantDTO {
   // Tenant code, unique identifier
   string tenant_code = 3;
 
-  // Enable flag: 1 enabled, 0 disabled
+  // Enable flag: 0 enabled, 1 disabled (EnableFlagEnum)
   int32 enable_flag = 4;
 }

--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/token.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/token.proto
@@ -41,14 +41,8 @@ message GrpcLoginQuery {
   // Login name
   string name = 2;
 
-  // Salt used for password encryption
-  string salt = 3;
-
-  // Login password
-  string password = 4;
-
   // Token
-  string token = 5;
+  string token = 3;
 }
 
 // Response wrapper for token validation result

--- a/dc3-api/dc3-api-data/src/main/protobuf/api/common/data/point_value.proto
+++ b/dc3-api/dc3-api-data/src/main/protobuf/api/common/data/point_value.proto
@@ -102,13 +102,13 @@ message GrpcPointValueHistoryQuery {
   int32 count = 4;
 }
 
-// Response wrapper for historical values (list of raw value strings)
+// Response wrapper for historical values (newest first, each with its timestamp)
 message GrpcRPointValueStringList {
   // Common result wrapper
   GrpcR result = 1;
 
-  // List of historical value strings
-  repeated string data = 2;
+  // Historical point values, each carrying its value and create_time.
+  repeated GrpcPointValueDTO data = 2;
 }
 
 // Request structure for sending a read command

--- a/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/tools/PointValueTool.java
+++ b/dc3-common/dc3-common-agentic/src/main/java/io/github/pnoker/common/agentic/tools/PointValueTool.java
@@ -95,15 +95,16 @@ public class PointValueTool {
                 "getPointValueHistory", tenantId, deviceId, pointId, count);
         int size = AgenticToolUtil.clamp(count, 1, AgenticConstant.ToolLimit.MAX_HISTORY_RECORDS);
         try {
-            List<String> history = pointValueFacade.history(tenantId, deviceId, pointId, size);
+            List<FacadePointValueBO> history = pointValueFacade.history(tenantId, deviceId, pointId, size);
             if (AgenticToolUtil.isEmpty(history)) {
                 return AgenticToolResult.empty("No history data found for device " + deviceId + " point " + pointId,
                         new PointValueHistory(deviceId, pointId, size, List.of(), null,
                                 AgenticVisualizationUtil.NumericSummary.empty(0)));
             }
+            List<String> values = history.stream().map(FacadePointValueBO::getValue).toList();
             AgenticVisualizationUtil.NumericSeries numericSeries =
-                    AgenticVisualizationUtil.numericSeriesFromNewestFirst(history);
-            PointValueHistory result = new PointValueHistory(deviceId, pointId, size, history,
+                    AgenticVisualizationUtil.numericSeriesFromNewestFirst(values);
+            PointValueHistory result = new PointValueHistory(deviceId, pointId, size, values,
                     buildHistoryChart(deviceId, pointId, numericSeries), numericSeries.summary());
             return AgenticToolResult.ok("Point value history loaded", result,
                     buildHistoryVisualizations(deviceId, pointId, numericSeries));

--- a/dc3-common/dc3-common-agentic/src/test/java/io/github/pnoker/common/agentic/tools/PointValueToolTest.java
+++ b/dc3-common/dc3-common-agentic/src/test/java/io/github/pnoker/common/agentic/tools/PointValueToolTest.java
@@ -23,6 +23,7 @@ import io.github.pnoker.common.constant.service.AgenticConstant;
 import io.github.pnoker.common.entity.common.RequestHeader;
 import io.github.pnoker.common.facade.api.PointCommandFacade;
 import io.github.pnoker.common.facade.api.PointValueFacade;
+import io.github.pnoker.common.facade.entity.bo.FacadePointValueBO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,7 +86,11 @@ class PointValueToolTest {
 
     @Test
     void getPointValueHistoryReturnsRawValuesAndChartData() {
-        when(pointValueFacade.history(1L, 10L, 20L, 5)).thenReturn(List.of("24.0", "23.8", "offline", "23.5"));
+        when(pointValueFacade.history(1L, 10L, 20L, 5)).thenReturn(List.of(
+                FacadePointValueBO.builder().value("24.0").build(),
+                FacadePointValueBO.builder().value("23.8").build(),
+                FacadePointValueBO.builder().value("offline").build(),
+                FacadePointValueBO.builder().value("23.5").build()));
 
         AgenticToolResult<PointValueTool.PointValueHistory> result = tool.getPointValueHistory(10L, 20L, 5,
                 toolContext(Map.of(AgenticConstant.ToolContextKey.USER_HEADER, header)));

--- a/dc3-common/dc3-common-api/src/main/protobuf/api/common/base.proto
+++ b/dc3-common/dc3-common-api/src/main/protobuf/api/common/base.proto
@@ -39,7 +39,7 @@ message GrpcBase {
   // Creator name
   string creator_name = 4;
 
-  // Creation time
+  // Creation time, epoch milliseconds
   int64 create_time = 5;
 
   // Operator ID
@@ -48,6 +48,6 @@ message GrpcBase {
   // Operator name
   string operator_name = 7;
 
-  // Operation time
+  // Operation time, epoch milliseconds
   int64 operate_time = 8;
 }

--- a/dc3-common/dc3-common-api/src/main/protobuf/api/common/r.proto
+++ b/dc3-common/dc3-common-api/src/main/protobuf/api/common/r.proto
@@ -27,8 +27,8 @@ option java_multiple_files = true;
 
 // R DTO
 message GrpcR {
-  // Success flag
-  bool ok = 1;
+  // Success flag (explicit presence so "unset" is distinguishable from false)
+  optional bool ok = 1;
 
   // Status code
   string code = 2;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/biz/TokenService.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/biz/TokenService.java
@@ -61,7 +61,7 @@ public interface TokenService {
      * @throws UnAuthorizedException           on bad tenant, credential, membership, salt, or password
      * @throws PasswordChangeRequiredException when password is expired or flagged for change
      */
-    String generateToken(String loginName, String salt, String password, String tenantCode);
+    String generateToken(String loginName, String password, String tenantCode);
 
     /**
      * Self-service password change used during login when a credential is flagged for a
@@ -88,7 +88,7 @@ public interface TokenService {
      * the JWT expiry time; never carries principal or tenant identifiers
      * @throws UnAuthorizedException when the tenant does not resolve
      */
-    TokenValid checkValid(String loginName, String salt, String token, String tenantCode);
+    TokenValid checkValid(String loginName, String token, String tenantCode);
 
     /**
      * Acknowledge a client-initiated logout by recording the logout instant on the

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/biz/impl/TokenServiceImpl.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/biz/impl/TokenServiceImpl.java
@@ -76,7 +76,7 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
-    public String generateToken(String loginName, String salt, String password, String tenantCode) {
+    public String generateToken(String loginName, String password, String tenantCode) {
         TenantBO tenantBO = tenantService.getByCode(tenantCode);
         if (Objects.isNull(tenantBO)) {
             throw new UnAuthorizedException(ExceptionConstant.NO_AVAILABLE_AUTH);
@@ -88,10 +88,6 @@ public class TokenServiceImpl implements TokenService {
         if (!tenantMembershipService.isTenantMember(tenantBO.getId(), credential.getPrincipalId())) {
             throw new UnAuthorizedException(ExceptionConstant.NO_AVAILABLE_AUTH);
         }
-        if (StringUtils.isEmpty(salt)) {
-            throw new UnAuthorizedException(ExceptionConstant.NO_AVAILABLE_AUTH);
-        }
-
         if (!localCredentialService.verifyPassword(credential, password)) {
             localCredentialService.recordFailedLogin(credential.getId());
             throw new UnAuthorizedException(ExceptionConstant.NO_AVAILABLE_AUTH);
@@ -107,7 +103,7 @@ public class TokenServiceImpl implements TokenService {
         }
 
         markPrincipalLogin(credential.getPrincipalId());
-        return KeyUtil.generateToken(String.valueOf(credential.getPrincipalId()), salt, tenantBO.getId());
+        return KeyUtil.generateToken(String.valueOf(credential.getPrincipalId()), tenantBO.getId());
     }
 
     @Override
@@ -144,7 +140,7 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
-    public TokenValid checkValid(String loginName, String salt, String token, String tenantCode) {
+    public TokenValid checkValid(String loginName, String token, String tenantCode) {
         TenantBO tenantBO = tenantService.getByCode(tenantCode);
         if (Objects.isNull(tenantBO)) {
             throw new UnAuthorizedException(ExceptionConstant.NO_AVAILABLE_AUTH);
@@ -163,7 +159,7 @@ public class TokenServiceImpl implements TokenService {
 
         try {
             String principalKey = String.valueOf(credential.getPrincipalId());
-            Claims claims = KeyUtil.parserToken(principalKey, salt, token, tenantBO.getId());
+            Claims claims = KeyUtil.parserToken(principalKey, token, tenantBO.getId());
             Date issuedAt = claims.getIssuedAt();
             long issuedAtEpochMs = Objects.nonNull(issuedAt) ? issuedAt.getTime() : 0L;
             if (tokenDenylistCache.isRevoked(principalKey, tenantCode, issuedAtEpochMs)) {

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/controller/TokenController.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/controller/TokenController.java
@@ -107,7 +107,7 @@ public class TokenController implements BaseController {
     @PostMapping("/generate")
     public Mono<R<String>> generateToken(@Validated @RequestBody TokenQuery entityVO) {
         return async(() -> {
-            String token = tokenService.generateToken(entityVO.getName(), entityVO.getSalt(), entityVO.getPassword(),
+            String token = tokenService.generateToken(entityVO.getName(), entityVO.getPassword(),
                     entityVO.getTenant());
             return Objects.nonNull(token) ? R.ok(token, "The token will expire in 12 hours.") : R.fail();
         });
@@ -184,7 +184,7 @@ public class TokenController implements BaseController {
     @PostMapping("/check")
     public Mono<R<Boolean>> checkValid(@Validated @RequestBody TokenQuery entityVO) {
         return async(() -> {
-            TokenValid tokenValid = tokenService.checkValid(entityVO.getName(), entityVO.getSalt(), entityVO.getToken(),
+            TokenValid tokenValid = tokenService.checkValid(entityVO.getName(), entityVO.getToken(),
                     entityVO.getTenant());
 
             boolean valid = tokenValid.isValid();

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
@@ -273,11 +273,19 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
      */
     private GrpcMcpToolAuthorizeDTO toGrpc(McpToolAuthorizeResponseDTO source) {
         return GrpcMcpToolAuthorizeDTO.newBuilder()
-                .setDecision(StringUtils.defaultString(source.getDecision()))
+                .setDecision(toGrpcDecision(source.getDecision()))
                 .setConfirmId(StringUtils.defaultString(source.getConfirmId()))
                 .setMessage(StringUtils.defaultString(source.getMessage()))
                 .setRiskLevel(StringUtils.defaultString(source.getRiskLevel()))
                 .build();
+    }
+
+    private GrpcMcpDecision toGrpcDecision(String value) {
+        try {
+            return GrpcMcpDecision.valueOf(StringUtils.defaultIfBlank(value, ""));
+        } catch (IllegalArgumentException e) {
+            return GrpcMcpDecision.MCP_DECISION_UNSPECIFIED;
+        }
     }
 
     /**

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/TokenServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/TokenServer.java
@@ -57,7 +57,7 @@ public class TokenServer extends TokenApiGrpc.TokenApiImplBase {
             // membership lookup reads dc3_tenant_membership (tenant_id-bearing, not
             // whitelisted), so run it with tenant filtering disabled.
             TokenValid entity = TenantContextHolder.runIgnore(() -> tokenService.checkValid(request.getName(),
-                    request.getSalt(), request.getToken(), request.getTenant()));
+                    request.getToken(), request.getTenant()));
             if (Objects.isNull(entity)) {
                 builder.setResult(GrpcRFactory.notFound());
             } else if (!entity.isValid()) {

--- a/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/biz/impl/TokenServiceImplTest.java
+++ b/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/biz/impl/TokenServiceImplTest.java
@@ -125,10 +125,10 @@ class TokenServiceImplTest {
         principal.setId(PRINCIPAL_ID);
         when(principalManager.getById(PRINCIPAL_ID)).thenReturn(principal);
 
-        String token = tokenService.generateToken(LOGIN, SALT, RAW_PASSWORD, TENANT_CODE);
+        String token = tokenService.generateToken(LOGIN,RAW_PASSWORD, TENANT_CODE);
 
         assertThat(token).isNotBlank();
-        assertThat(KeyUtil.parserToken(String.valueOf(PRINCIPAL_ID), SALT, token, TENANT_ID)).isNotNull();
+        assertThat(KeyUtil.parserToken(String.valueOf(PRINCIPAL_ID),token, TENANT_ID)).isNotNull();
         verify(localCredentialService).recordSuccessfulLogin(CREDENTIAL_ID);
         verify(localCredentialService, never()).recordFailedLogin(anyLong());
         verify(principalManager).updateById(any(PrincipalDO.class));
@@ -137,7 +137,7 @@ class TokenServiceImplTest {
     @Test
     void generateTokenRejectsUnknownTenant() {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(null);
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, SALT, RAW_PASSWORD, TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.generateToken(LOGIN,RAW_PASSWORD, TENANT_CODE))
                 .isInstanceOf(UnAuthorizedException.class);
     }
 
@@ -145,7 +145,7 @@ class TokenServiceImplTest {
     void generateTokenRejectsUnknownLogin() {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
         when(localCredentialService.getByLoginName(LOGIN, false)).thenReturn(null);
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, SALT, RAW_PASSWORD, TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.generateToken(LOGIN,RAW_PASSWORD, TENANT_CODE))
                 .isInstanceOf(UnAuthorizedException.class);
     }
 
@@ -154,16 +154,7 @@ class TokenServiceImplTest {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
         when(localCredentialService.getByLoginName(LOGIN, false)).thenReturn(credential);
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(false);
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, SALT, RAW_PASSWORD, TENANT_CODE))
-                .isInstanceOf(UnAuthorizedException.class);
-    }
-
-    @Test
-    void generateTokenRejectsBlankSalt() {
-        when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
-        when(localCredentialService.getByLoginName(LOGIN, false)).thenReturn(credential);
-        when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, "", RAW_PASSWORD, TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.generateToken(LOGIN,RAW_PASSWORD, TENANT_CODE))
                 .isInstanceOf(UnAuthorizedException.class);
     }
 
@@ -174,7 +165,7 @@ class TokenServiceImplTest {
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
         when(localCredentialService.verifyPassword(credential, "wrong")).thenReturn(false);
 
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, SALT, "wrong", TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.generateToken(LOGIN,"wrong", TENANT_CODE))
                 .isInstanceOf(UnAuthorizedException.class);
         verify(localCredentialService).recordFailedLogin(CREDENTIAL_ID);
     }
@@ -187,7 +178,7 @@ class TokenServiceImplTest {
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
         when(localCredentialService.verifyPassword(credential, RAW_PASSWORD)).thenReturn(true);
 
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, SALT, RAW_PASSWORD, TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.generateToken(LOGIN,RAW_PASSWORD, TENANT_CODE))
                 .isInstanceOf(PasswordChangeRequiredException.class)
                 .extracting(e -> ((PasswordChangeRequiredException) e).getErrorCode())
                 .isEqualTo(ErrorCode.PASSWORD_EXPIRED);
@@ -203,7 +194,7 @@ class TokenServiceImplTest {
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
         when(localCredentialService.verifyPassword(credential, RAW_PASSWORD)).thenReturn(true);
 
-        assertThatThrownBy(() -> tokenService.generateToken(LOGIN, SALT, RAW_PASSWORD, TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.generateToken(LOGIN,RAW_PASSWORD, TENANT_CODE))
                 .isInstanceOf(PasswordChangeRequiredException.class)
                 .extracting(e -> ((PasswordChangeRequiredException) e).getErrorCode())
                 .isEqualTo(ErrorCode.PASSWORD_CHANGE_REQUIRED);
@@ -235,14 +226,14 @@ class TokenServiceImplTest {
     @Test
     void checkValidRejectsUnknownTenant() {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(null);
-        assertThatThrownBy(() -> tokenService.checkValid(LOGIN, SALT, "token", TENANT_CODE))
+        assertThatThrownBy(() -> tokenService.checkValid(LOGIN,"token", TENANT_CODE))
                 .isInstanceOf(UnAuthorizedException.class);
     }
 
     @Test
     void checkValidReturnsInvalidForBlankToken() {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
-        TokenValid result = tokenService.checkValid(LOGIN, SALT, "", TENANT_CODE);
+        TokenValid result = tokenService.checkValid(LOGIN,"", TENANT_CODE);
         assertThat(result.isValid()).isFalse();
         assertThat(result.getExpireTime()).isNull();
     }
@@ -251,7 +242,7 @@ class TokenServiceImplTest {
     void checkValidReturnsInvalidWhenLoginUnknown() {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
         when(localCredentialService.getByLoginName(LOGIN, false)).thenReturn(null);
-        TokenValid result = tokenService.checkValid(LOGIN, SALT, "any-token", TENANT_CODE);
+        TokenValid result = tokenService.checkValid(LOGIN,"any-token", TENANT_CODE);
         assertThat(result.isValid()).isFalse();
     }
 
@@ -260,7 +251,7 @@ class TokenServiceImplTest {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
         when(localCredentialService.getByLoginName(LOGIN, false)).thenReturn(credential);
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(false);
-        TokenValid result = tokenService.checkValid(LOGIN, SALT, "any-token", TENANT_CODE);
+        TokenValid result = tokenService.checkValid(LOGIN,"any-token", TENANT_CODE);
         assertThat(result.isValid()).isFalse();
     }
 
@@ -271,9 +262,9 @@ class TokenServiceImplTest {
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
         when(tokenDenylistCache.isRevoked(eq(String.valueOf(PRINCIPAL_ID)), eq(TENANT_CODE), anyLong()))
                 .thenReturn(false);
-        String token = KeyUtil.generateToken(String.valueOf(PRINCIPAL_ID), SALT, TENANT_ID);
+        String token = KeyUtil.generateToken(String.valueOf(PRINCIPAL_ID),TENANT_ID);
 
-        TokenValid result = tokenService.checkValid(LOGIN, SALT, token, TENANT_CODE);
+        TokenValid result = tokenService.checkValid(LOGIN,token, TENANT_CODE);
 
         assertThat(result.isValid()).isTrue();
         assertThat(result.getExpireTime()).isNotNull();
@@ -286,9 +277,9 @@ class TokenServiceImplTest {
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
         when(tokenDenylistCache.isRevoked(eq(String.valueOf(PRINCIPAL_ID)), eq(TENANT_CODE), anyLong()))
                 .thenReturn(true);
-        String token = KeyUtil.generateToken(String.valueOf(PRINCIPAL_ID), SALT, TENANT_ID);
+        String token = KeyUtil.generateToken(String.valueOf(PRINCIPAL_ID),TENANT_ID);
 
-        TokenValid result = tokenService.checkValid(LOGIN, SALT, token, TENANT_CODE);
+        TokenValid result = tokenService.checkValid(LOGIN,token, TENANT_CODE);
 
         assertThat(result.isValid()).isFalse();
         assertThat(result.getExpireTime()).isNotNull();
@@ -299,7 +290,7 @@ class TokenServiceImplTest {
         when(tenantService.getByCode(TENANT_CODE)).thenReturn(tenant);
         when(localCredentialService.getByLoginName(LOGIN, false)).thenReturn(credential);
         when(tenantMembershipService.isTenantMember(TENANT_ID, PRINCIPAL_ID)).thenReturn(true);
-        TokenValid result = tokenService.checkValid(LOGIN, SALT, "garbage-token", TENANT_CODE);
+        TokenValid result = tokenService.checkValid(LOGIN,"garbage-token", TENANT_CODE);
         assertThat(result.isValid()).isFalse();
     }
 

--- a/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/controller/TokenControllerTest.java
+++ b/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/controller/TokenControllerTest.java
@@ -88,7 +88,7 @@ class TokenControllerTest {
     @Test
     void generateTokenSucceedsWithExpiryMessage() {
         when(tokenService.generateToken("alice",
-                "0123456789abcdef0123456789abcdef", "hash", "tenant-A"))
+                "hash", "tenant-A"))
                 .thenReturn("jwt-token");
 
         StepVerifier.create(controller.generateToken(query()))
@@ -103,7 +103,7 @@ class TokenControllerTest {
     @Test
     void generateTokenReturnsFailWhenServiceReturnsNull() {
         when(tokenService.generateToken("alice",
-                "0123456789abcdef0123456789abcdef", "hash", "tenant-A"))
+                "hash", "tenant-A"))
                 .thenReturn(null);
 
         StepVerifier.create(controller.generateToken(query()))
@@ -115,7 +115,7 @@ class TokenControllerTest {
     void checkValidReturnsTrueWithRemainingExpiryMessage() {
         TokenValid valid = new TokenValid(true, new Date(1_700_000_000_000L));
         when(tokenService.checkValid("alice",
-                "0123456789abcdef0123456789abcdef", "token", "tenant-A"))
+                "token", "tenant-A"))
                 .thenReturn(valid);
 
         StepVerifier.create(controller.checkValid(query()))
@@ -131,7 +131,7 @@ class TokenControllerTest {
     void checkValidReturnsFalseWithExpiredMessageWhenExpiryKnown() {
         TokenValid invalidWithExpiry = new TokenValid(false, new Date(1_700_000_000_000L));
         when(tokenService.checkValid("alice",
-                "0123456789abcdef0123456789abcdef", "token", "tenant-A"))
+                "token", "tenant-A"))
                 .thenReturn(invalidWithExpiry);
 
         StepVerifier.create(controller.checkValid(query()))
@@ -147,7 +147,7 @@ class TokenControllerTest {
     void checkValidReturnsFalseWithGenericMessageWhenExpiryUnknown() {
         TokenValid invalidNoExpiry = new TokenValid(false, null);
         when(tokenService.checkValid("alice",
-                "0123456789abcdef0123456789abcdef", "token", "tenant-A"))
+                "token", "tenant-A"))
                 .thenReturn(invalidNoExpiry);
 
         StepVerifier.<R<Boolean>>create(controller.checkValid(query()))

--- a/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/grpc/TokenServerTest.java
+++ b/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/grpc/TokenServerTest.java
@@ -74,12 +74,11 @@ class TokenServerTest {
     @Test
     void checkValidReportsOkWithExpiryDataForValidToken() {
         TokenValid valid = new TokenValid(true, new Date(1_700_000_000_000L));
-        when(tokenService.checkValid("alice", "salt", "token", "tenant-A")).thenReturn(valid);
+        when(tokenService.checkValid("alice", "token", "tenant-A")).thenReturn(valid);
 
         GrpcRTokenDTO response = stub.checkValid(GrpcLoginQuery.newBuilder()
                 .setTenant("tenant-A")
                 .setName("alice")
-                .setSalt("salt")
                 .setToken("token")
                 .build());
 
@@ -90,13 +89,12 @@ class TokenServerTest {
 
     @Test
     void checkValidReportsTokenInvalidEnvelopeForInvalidToken() {
-        when(tokenService.checkValid("alice", "salt", "token", "tenant-A"))
+        when(tokenService.checkValid("alice", "token", "tenant-A"))
                 .thenReturn(new TokenValid(false, null));
 
         GrpcRTokenDTO response = stub.checkValid(GrpcLoginQuery.newBuilder()
                 .setTenant("tenant-A")
                 .setName("alice")
-                .setSalt("salt")
                 .setToken("token")
                 .build());
 
@@ -107,12 +105,11 @@ class TokenServerTest {
 
     @Test
     void checkValidReportsNoResourceWhenServiceReturnsNull() {
-        when(tokenService.checkValid("alice", "salt", "token", "tenant-A")).thenReturn(null);
+        when(tokenService.checkValid("alice", "token", "tenant-A")).thenReturn(null);
 
         GrpcRTokenDTO response = stub.checkValid(GrpcLoginQuery.newBuilder()
                 .setTenant("tenant-A")
                 .setName("alice")
-                .setSalt("salt")
                 .setToken("token")
                 .build());
 

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/PointValueService.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/PointValueService.java
@@ -53,9 +53,9 @@ public interface PointValueService {
      * @param deviceId Device ID
      * @param pointId  Point ID
      * @param count    Number of values to retrieve
-     * @return History Value Array
+     * @return History values (each with create_time), newest first
      */
-    List<String> history(Long tenantId, Long deviceId, Long pointId, int count);
+    List<PointValueBO> history(Long tenantId, Long deviceId, Long pointId, int count);
 
     /**
      * Get latest point values with pagination and sorting

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/impl/PointValueServiceImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/impl/PointValueServiceImpl.java
@@ -114,7 +114,7 @@ public class PointValueServiceImpl implements PointValueService {
     }
 
     @Override
-    public List<String> history(Long tenantId, Long deviceId, Long pointId, int count) {
+    public List<PointValueBO> history(Long tenantId, Long deviceId, Long pointId, int count) {
         if (Objects.isNull(tenantId) || Objects.isNull(deviceId) || Objects.isNull(pointId)) {
             return Collections.emptyList();
         }

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/repository/PostgresRepositoryServiceImpl.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/biz/repository/PostgresRepositoryServiceImpl.java
@@ -85,7 +85,7 @@ public class PostgresRepositoryServiceImpl implements RepositoryService, Initial
     }
 
     @Override
-    public List<String> listHistoryPointValue(Long tenantId, Long deviceId, Long pointId, int count) {
+    public List<PointValueBO> listHistoryPointValue(Long tenantId, Long deviceId, Long pointId, int count) {
         LambdaQueryWrapper<PointValueDO> wrapper = Wrappers.<PointValueDO>query().lambda();
         wrapper.eq(PointValueDO::getTenantId, tenantId);
         wrapper.eq(PointValueDO::getDeviceId, deviceId);
@@ -97,7 +97,7 @@ public class PostgresRepositoryServiceImpl implements RepositoryService, Initial
         wrapper.last("LIMIT " + Math.max(1, count));
 
         List<PointValueDO> entityPageDO = pointValueManager.list(wrapper);
-        return entityPageDO.stream().map(PointValueDO::getCalValue).toList();
+        return entityPageDO.stream().map(pointValueBuilder::buildBOByDO).toList();
     }
 
     @Override

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/controller/PointValueController.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/controller/PointValueController.java
@@ -134,12 +134,12 @@ public class PointValueController implements BaseController {
                     @ExtensionProperty(name = "openWorld", value = "false")
             }))
     @GetMapping("/list_history_by_device_id_and_point_id")
-    public Mono<R<List<String>>> history(@Parameter(description = "Identifier of the device; must belong to the current tenant", example = "1024") @NotNull @RequestParam(name = "device_id") Long deviceId,
+    public Mono<R<List<PointValueBO>>> history(@Parameter(description = "Identifier of the device; must belong to the current tenant", example = "1024") @NotNull @RequestParam(name = "device_id") Long deviceId,
                                          @Parameter(description = "Identifier of the point whose history is being queried; must belong to a profile attached to the device", example = "2048") @NotNull @RequestParam(name = "point_id") Long pointId,
                                          @Parameter(description = "Maximum number of historical values to return; defaults to 100 when omitted", example = "100")
                                          @RequestParam(name = "count", required = false, defaultValue = "100") Integer count) {
         return getTenantId().flatMap(tenantId -> async(() -> {
-            List<String> history = pointValueService.history(tenantId, deviceId, pointId, count);
+            List<PointValueBO> history = pointValueService.history(tenantId, deviceId, pointId, count);
             return R.ok(history);
         }));
     }

--- a/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/PointValueServer.java
+++ b/dc3-common/dc3-common-data/src/main/java/io/github/pnoker/common/data/grpc/server/PointValueServer.java
@@ -82,16 +82,7 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
                 response.setResult(GrpcRFactory.ok());
 
                 io.github.pnoker.common.entity.bo.PointValueBO bo = page.getRecords().getFirst();
-                response.setData(GrpcPointValueDTO.newBuilder()
-                        .setId(0)
-                        .setDeviceId(Objects.nonNull(bo.getDeviceId()) ? bo.getDeviceId() : 0)
-                        .setPointId(Objects.nonNull(bo.getPointId()) ? bo.getPointId() : 0)
-                        .setValue(Objects.nonNull(bo.getCalValue()) ? bo.getCalValue() : "")
-                        .setRawValue(Objects.nonNull(bo.getRawValue()) ? bo.getRawValue() : "")
-                        .setNumValue(Objects.nonNull(bo.getNumValue()) ? bo.getNumValue() : 0d)
-                        .setCreateTime(
-                                Objects.nonNull(bo.getCreateTime()) ? bo.getCreateTime().toEpochSecond(java.time.ZoneOffset.UTC) : 0)
-                        .build());
+                response.setData(toGrpcDTO(bo));
             }
             responseObserver.onNext(response.build());
             responseObserver.onCompleted();
@@ -112,14 +103,14 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
                                   StreamObserver<GrpcRPointValueStringList> responseObserver) {
         TenantContextHolder.setTenantId(request.getTenantId());
         try {
-            List<String> history = pointValueService.history(request.getTenantId(), request.getDeviceId(),
+            List<io.github.pnoker.common.entity.bo.PointValueBO> history = pointValueService.history(request.getTenantId(), request.getDeviceId(),
                     request.getPointId(), request.getCount());
 
             GrpcRPointValueStringList.Builder response = GrpcRPointValueStringList.newBuilder()
                     .setResult(GrpcRFactory.ok());
 
             if (Objects.nonNull(history)) {
-                response.addAllData(history);
+                response.addAllData(history.stream().map(this::toGrpcDTO).toList());
             }
             responseObserver.onNext(response.build());
             responseObserver.onCompleted();
@@ -133,6 +124,19 @@ public class PointValueServer extends PointValueApiGrpc.PointValueApiImplBase {
         } finally {
             TenantContextHolder.clear();
         }
+    }
+
+    private GrpcPointValueDTO toGrpcDTO(io.github.pnoker.common.entity.bo.PointValueBO bo) {
+        return GrpcPointValueDTO.newBuilder()
+                .setId(0)
+                .setDeviceId(Objects.nonNull(bo.getDeviceId()) ? bo.getDeviceId() : 0)
+                .setPointId(Objects.nonNull(bo.getPointId()) ? bo.getPointId() : 0)
+                .setValue(Objects.nonNull(bo.getCalValue()) ? bo.getCalValue() : "")
+                .setRawValue(Objects.nonNull(bo.getRawValue()) ? bo.getRawValue() : "")
+                .setNumValue(Objects.nonNull(bo.getNumValue()) ? bo.getNumValue() : 0d)
+                .setCreateTime(
+                        Objects.nonNull(bo.getCreateTime()) ? bo.getCreateTime().toEpochSecond(java.time.ZoneOffset.UTC) : 0)
+                .build();
     }
 
     @Override

--- a/dc3-common/dc3-common-data/src/test/java/io/github/pnoker/common/data/grpc/server/PointValueServerTest.java
+++ b/dc3-common/dc3-common-data/src/test/java/io/github/pnoker/common/data/grpc/server/PointValueServerTest.java
@@ -19,6 +19,7 @@ package io.github.pnoker.common.data.grpc.server;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.github.pnoker.api.center.data.GrpcPointValueCommandQuery;
+import io.github.pnoker.api.center.data.GrpcPointValueDTO;
 import io.github.pnoker.api.center.data.GrpcPointValueHistoryQuery;
 import io.github.pnoker.api.center.data.GrpcPointValueQuery;
 import io.github.pnoker.api.center.data.GrpcPointValueWriteCommand;
@@ -133,13 +134,16 @@ class PointValueServerTest {
     @Test
     void historyValueReturnsListFromService() {
         when(pointValueService.history(eq(1L), eq(10L), eq(20L), eq(50)))
-                .thenReturn(List.of("v1", "v2", "v3"));
+                .thenReturn(List.of(
+                        PointValueBO.builder().calValue("v1").build(),
+                        PointValueBO.builder().calValue("v2").build(),
+                        PointValueBO.builder().calValue("v3").build()));
 
         GrpcRPointValueStringList response = stub.listHistoryValues(GrpcPointValueHistoryQuery.newBuilder()
                 .setTenantId(1L).setDeviceId(10L).setPointId(20L).setCount(50)
                 .build());
         assertThat(response.getResult().getOk()).isTrue();
-        assertThat(response.getDataList()).containsExactly("v1", "v2", "v3");
+        assertThat(response.getDataList()).map(GrpcPointValueDTO::getValue).containsExactly("v1", "v2", "v3");
     }
 
     @Test

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/PointValueFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/PointValueFacade.java
@@ -50,9 +50,9 @@ public interface PointValueFacade {
     /**
      * Query historical values of a device point.
      *
-     * @return an immutable list of value strings (never {@code null}; empty when nothing
+     * @return an immutable list of point values with timestamps (never {@code null}; empty when nothing
      * matches).
      */
-    List<String> history(Long tenantId, Long deviceId, Long pointId, int count);
+    List<FacadePointValueBO> history(Long tenantId, Long deviceId, Long pointId, int count);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/TokenFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-api/src/main/java/io/github/pnoker/common/facade/api/TokenFacade.java
@@ -39,6 +39,6 @@ public interface TokenFacade {
      * @param token  token the client holds
      * @return {@code true} when the triple is valid and unexpired
      */
-    boolean checkValid(String tenant, String name, String salt, String token);
+    boolean checkValid(String tenant, String name, String token);
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
@@ -123,7 +123,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
 
     private McpToolAuthorizeResponseDTO toDTO(GrpcMcpToolAuthorizeDTO source) {
         return McpToolAuthorizeResponseDTO.builder()
-                .decision(source.getDecision())
+                .decision(source.getDecision().name())
                 .confirmId(source.getConfirmId())
                 .message(source.getMessage())
                 .riskLevel(source.getRiskLevel())

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/PointValueGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/PointValueGrpcFacade.java
@@ -77,7 +77,7 @@ public class PointValueGrpcFacade implements PointValueFacade {
     }
 
     @Override
-    public List<String> history(Long tenantId, Long deviceId, Long pointId, int count) {
+    public List<FacadePointValueBO> history(Long tenantId, Long deviceId, Long pointId, int count) {
         GrpcPointValueHistoryQuery request = GrpcPointValueHistoryQuery.newBuilder()
                 .setDeviceId(deviceId)
                 .setPointId(pointId)
@@ -90,7 +90,7 @@ public class PointValueGrpcFacade implements PointValueFacade {
             guardOrThrow(response.getResult(), "listHistoryValues");
             return Collections.emptyList();
         }
-        return response.getDataList();
+        return response.getDataList().stream().map(facadeGrpcPointValueBuilder::toFacadeBO).toList();
     }
 
     /**

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/TokenGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/TokenGrpcFacade.java
@@ -42,11 +42,10 @@ public class TokenGrpcFacade implements TokenFacade {
     private final GrpcFacadeSupport grpcFacadeSupport;
 
     @Override
-    public boolean checkValid(String tenant, String name, String salt, String token) {
+    public boolean checkValid(String tenant, String name, String token) {
         GrpcLoginQuery login = GrpcLoginQuery.newBuilder()
                 .setTenant(tenant)
                 .setName(name)
-                .setSalt(salt)
                 .setToken(token)
                 .build();
         GrpcRTokenDTO response = grpcFacadeSupport.call("TokenFacade.checkValid", tokenApiBlockingStub,

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-auth/src/main/java/io/github/pnoker/common/facade/local/TokenLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-auth/src/main/java/io/github/pnoker/common/facade/local/TokenLocalFacade.java
@@ -42,8 +42,8 @@ public class TokenLocalFacade implements TokenFacade {
     private final TokenService tokenService;
 
     @Override
-    public boolean checkValid(String tenant, String name, String salt, String token) {
-        TokenValid entity = tokenService.checkValid(name, salt, token, tenant);
+    public boolean checkValid(String tenant, String name, String token) {
+        TokenValid entity = tokenService.checkValid(name, token, tenant);
         return Objects.nonNull(entity) && entity.isValid();
     }
 

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-auth/src/test/java/io/github/pnoker/common/facade/local/TokenLocalFacadeTest.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-auth/src/test/java/io/github/pnoker/common/facade/local/TokenLocalFacadeTest.java
@@ -43,23 +43,23 @@ class TokenLocalFacadeTest {
 
     @Test
     void checkValidReturnsFalseWhenServiceReturnsNull() {
-        when(tokenService.checkValid("alice", "salt", "token", "tenant-A")).thenReturn(null);
-        assertThat(facade.checkValid("tenant-A", "alice", "salt", "token")).isFalse();
+        when(tokenService.checkValid("alice", "token", "tenant-A")).thenReturn(null);
+        assertThat(facade.checkValid("tenant-A", "alice", "token")).isFalse();
     }
 
     @Test
     void checkValidReturnsFalseWhenTokenInvalid() {
         TokenValid invalid = new TokenValid();
         invalid.setValid(false);
-        when(tokenService.checkValid("alice", "salt", "token", "tenant-A")).thenReturn(invalid);
-        assertThat(facade.checkValid("tenant-A", "alice", "salt", "token")).isFalse();
+        when(tokenService.checkValid("alice", "token", "tenant-A")).thenReturn(invalid);
+        assertThat(facade.checkValid("tenant-A", "alice", "token")).isFalse();
     }
 
     @Test
     void checkValidReturnsTrueWhenTokenValid() {
         TokenValid valid = new TokenValid();
         valid.setValid(true);
-        when(tokenService.checkValid("alice", "salt", "token", "tenant-A")).thenReturn(valid);
-        assertThat(facade.checkValid("tenant-A", "alice", "salt", "token")).isTrue();
+        when(tokenService.checkValid("alice", "token", "tenant-A")).thenReturn(valid);
+        assertThat(facade.checkValid("tenant-A", "alice", "token")).isTrue();
     }
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-data/src/main/java/io/github/pnoker/common/facade/local/PointValueLocalFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-data/src/main/java/io/github/pnoker/common/facade/local/PointValueLocalFacade.java
@@ -66,12 +66,12 @@ public class PointValueLocalFacade implements PointValueFacade {
     }
 
     @Override
-    public List<String> history(Long tenantId, Long deviceId, Long pointId, int count) {
-        List<String> result = pointValueService.history(tenantId, deviceId, pointId, count);
+    public List<FacadePointValueBO> history(Long tenantId, Long deviceId, Long pointId, int count) {
+        List<PointValueBO> result = pointValueService.history(tenantId, deviceId, pointId, count);
         if (Objects.isNull(result) || result.isEmpty()) {
             return Collections.emptyList();
         }
-        return result;
+        return result.stream().map(facadePointValueBuilder::toFacadeBO).toList();
     }
 
 }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-local-data/src/test/java/io/github/pnoker/common/facade/local/PointValueLocalFacadeTest.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-local-data/src/test/java/io/github/pnoker/common/facade/local/PointValueLocalFacadeTest.java
@@ -105,8 +105,13 @@ class PointValueLocalFacadeTest {
 
     @Test
     void historyForwardsServiceResultUnchanged() {
-        when(pointValueService.history(1L, 2L, 3L, 10)).thenReturn(List.of("23.5", "24.0"));
-        assertThat(facade.history(1L, 2L, 3L, 10)).containsExactly("23.5", "24.0");
+        when(pointValueService.history(1L, 2L, 3L, 10)).thenReturn(List.of(
+                PointValueBO.builder().calValue("23.5").build(),
+                PointValueBO.builder().calValue("24.0").build()));
+        when(facadePointValueBuilder.toFacadeBO(any(PointValueBO.class))).thenAnswer(inv ->
+                FacadePointValueBO.builder().value(inv.<PointValueBO>getArgument(0).getCalValue()).build());
+        assertThat(facade.history(1L, 2L, 3L, 10))
+                .map(FacadePointValueBO::getValue).containsExactly("23.5", "24.0");
     }
 
 }

--- a/dc3-common/dc3-common-gateway/src/main/java/io/github/pnoker/common/gateway/service/impl/FilterServiceImpl.java
+++ b/dc3-common/dc3-common-gateway/src/main/java/io/github/pnoker/common/gateway/service/impl/FilterServiceImpl.java
@@ -142,12 +142,12 @@ public class FilterServiceImpl implements FilterService {
         } catch (Exception e) {
             throw new UnAuthorizedException(RequestConstant.Message.INVALID_REQUEST, e);
         }
-        if (Objects.isNull(header) || StringUtils.isAnyEmpty(header.getSalt(), header.getToken())) {
+        if (Objects.isNull(header) || StringUtils.isEmpty(header.getToken())) {
             throw new UnAuthorizedException(RequestConstant.Message.INVALID_REQUEST);
         }
 
         // Token validity is intentionally NOT cached — it's the freshness check.
-        boolean valid = tokenFacade.checkValid(tenant.getTenantCode(), credential.getLoginName(), header.getSalt(),
+        boolean valid = tokenFacade.checkValid(tenant.getTenantCode(), credential.getLoginName(),
                 header.getToken());
         if (!valid) {
             throw new UnAuthorizedException(RequestConstant.Message.INVALID_REQUEST);

--- a/dc3-common/dc3-common-gateway/src/test/java/io/github/pnoker/common/gateway/service/impl/FilterServiceImplTest.java
+++ b/dc3-common/dc3-common-gateway/src/test/java/io/github/pnoker/common/gateway/service/impl/FilterServiceImplTest.java
@@ -173,12 +173,12 @@ class FilterServiceImplTest {
         FacadeLocalCredentialBO credential = credential("alice", 100L, EnableFlagEnum.ENABLE);
         String tokenHeader = JsonUtil.toJsonString(new RequestHeader.TokenHeader("salt", "token"));
         ServerHttpRequest request = request("acme", "alice", tokenHeader);
-        when(tokenFacade.checkValid("acme", "alice", "salt", "token")).thenReturn(true);
+        when(tokenFacade.checkValid("acme", "alice", "token")).thenReturn(true);
 
         filterService.checkValid(request, tenant, credential);
         filterService.checkValid(request, tenant, credential);
 
-        verify(tokenFacade, times(2)).checkValid("acme", "alice", "salt", "token");
+        verify(tokenFacade, times(2)).checkValid("acme", "alice", "token");
     }
 
     @Test
@@ -192,7 +192,7 @@ class FilterServiceImplTest {
                 JsonUtil.toJsonString(new RequestHeader.TokenHeader("salt", ""))), tenant, credential))
                 .isInstanceOf(UnAuthorizedException.class);
 
-        when(tokenFacade.checkValid("acme", "alice", "salt", "token")).thenReturn(false);
+        when(tokenFacade.checkValid("acme", "alice", "token")).thenReturn(false);
 
         assertThatThrownBy(() -> filterService.checkValid(request("acme", "alice",
                 JsonUtil.toJsonString(new RequestHeader.TokenHeader("salt", "token"))), tenant, credential))

--- a/dc3-common/dc3-common-public/src/main/java/io/github/pnoker/common/utils/KeyUtil.java
+++ b/dc3-common/dc3-common-public/src/main/java/io/github/pnoker/common/utils/KeyUtil.java
@@ -254,14 +254,13 @@ public class KeyUtil {
      * Generate a JWT token.
      *
      * @param subject  token subject, normally principal ID
-     * @param salt     Salt
      * @param tenantId Tenant ID
      * @return Token string
      */
-    public static String generateToken(String subject, String salt, Long tenantId) {
+    public static String generateToken(String subject, Long tenantId) {
         String securityKey = getSecurityKey();
         SecretKey key = io.jsonwebtoken.security.Keys
-                .hmacShaKeyFor(DecodeUtil.stringToByte(securityKey + SymbolConstant.COLON + salt));
+                .hmacShaKeyFor(DecodeUtil.stringToByte(securityKey));
         JwtBuilder builder = Jwts.builder()
                 .issuer(securityKey + SymbolConstant.COLON + tenantId)
                 .subject(securityKey + SymbolConstant.COLON + subject)
@@ -275,15 +274,14 @@ public class KeyUtil {
      * Parse and validate a JWT token.
      *
      * @param subject  token subject, normally principal ID
-     * @param salt     Salt
      * @param token    Token string
      * @param tenantId Tenant ID
      * @return Claims
      */
-    public static Claims parserToken(String subject, String salt, String token, Long tenantId) {
+    public static Claims parserToken(String subject, String token, Long tenantId) {
         String securityKey = getSecurityKey();
         SecretKey key = io.jsonwebtoken.security.Keys
-                .hmacShaKeyFor(DecodeUtil.stringToByte(securityKey + SymbolConstant.COLON + salt));
+                .hmacShaKeyFor(DecodeUtil.stringToByte(securityKey));
         JwtParser parser = Jwts.parser()
                 .requireIssuer(securityKey + SymbolConstant.COLON + tenantId)
                 .requireSubject(securityKey + SymbolConstant.COLON + subject)

--- a/dc3-common/dc3-common-public/src/test/java/io/github/pnoker/common/utils/KeyUtilTest.java
+++ b/dc3-common/dc3-common-public/src/test/java/io/github/pnoker/common/utils/KeyUtilTest.java
@@ -32,13 +32,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KeyUtilTest {
 
-    private static final String SALT = "0123456789abcdef0123456789abcdef";
-
-    private static final String OTHER_SALT = "fedcba9876543210fedcba9876543210";
-
     @BeforeAll
     static void setUpSecurityKey() {
-        System.setProperty("dc3.security.key", "test-security-key-for-junit");
+        System.setProperty("dc3.security.key", "test-security-key-for-junit-0123456789abcdef");
     }
 
     @AfterAll
@@ -88,31 +84,24 @@ class KeyUtilTest {
 
     @Test
     void jwtRoundTripsForValidIssuerAndSubject() {
-        String token = KeyUtil.generateToken("alice", SALT, 100L);
-        Claims claims = KeyUtil.parserToken("alice", SALT, token, 100L);
+        String token = KeyUtil.generateToken("alice",100L);
+        Claims claims = KeyUtil.parserToken("alice",token, 100L);
         assertThat(claims.getSubject()).contains("alice");
         assertThat(claims.getIssuer()).contains("100");
         assertThat(claims.getExpiration()).isAfter(claims.getIssuedAt());
     }
 
     @Test
-    void jwtParsingRejectsTokenSignedWithDifferentSalt() {
-        String token = KeyUtil.generateToken("alice", SALT, 100L);
-        assertThatThrownBy(() -> KeyUtil.parserToken("alice", OTHER_SALT, token, 100L))
-                .isInstanceOf(SignatureException.class);
-    }
-
-    @Test
     void jwtParsingRejectsTokenForDifferentSubject() {
-        String token = KeyUtil.generateToken("alice", SALT, 100L);
-        assertThatThrownBy(() -> KeyUtil.parserToken("bob", SALT, token, 100L))
+        String token = KeyUtil.generateToken("alice",100L);
+        assertThatThrownBy(() -> KeyUtil.parserToken("bob",token, 100L))
                 .isInstanceOf(io.jsonwebtoken.IncorrectClaimException.class);
     }
 
     @Test
     void jwtParsingRejectsTokenForDifferentTenant() {
-        String token = KeyUtil.generateToken("alice", SALT, 100L);
-        assertThatThrownBy(() -> KeyUtil.parserToken("alice", SALT, token, 200L))
+        String token = KeyUtil.generateToken("alice",100L);
+        assertThatThrownBy(() -> KeyUtil.parserToken("alice",token, 200L))
                 .isInstanceOf(io.jsonwebtoken.IncorrectClaimException.class);
     }
 

--- a/dc3-common/dc3-common-repository/src/main/java/io/github/pnoker/common/repository/RepositoryService.java
+++ b/dc3-common/dc3-common-repository/src/main/java/io/github/pnoker/common/repository/RepositoryService.java
@@ -66,9 +66,9 @@ public interface RepositoryService {
      * @param deviceId device ID
      * @param pointId  point ID
      * @param count    maximum number of records to retrieve
-     * @return list of serialized point value strings, newest first
+     * @return list of point values (each with create_time), newest first
      */
-    List<String> listHistoryPointValue(Long tenantId, Long deviceId, Long pointId, int count);
+    List<PointValueBO> listHistoryPointValue(Long tenantId, Long deviceId, Long pointId, int count);
 
     /**
      * Query the latest point value within the tenant scope.

--- a/dc3-common/dc3-common-repository/src/test/java/io/github/pnoker/common/strategy/RepositoryStrategyFactoryTest.java
+++ b/dc3-common/dc3-common-repository/src/test/java/io/github/pnoker/common/strategy/RepositoryStrategyFactoryTest.java
@@ -147,7 +147,7 @@ class RepositoryStrategyFactoryTest {
         }
 
         @Override
-        public List<String> listHistoryPointValue(Long tenantId, Long deviceId, Long pointId, int count) {
+        public List<PointValueBO> listHistoryPointValue(Long tenantId, Long deviceId, Long pointId, int count) {
             return List.of();
         }
 

--- a/dc3-web/package.json
+++ b/dc3-web/package.json
@@ -28,6 +28,7 @@
     "dev:prod": "vite --host --mode production",
     "serve:e2e": "vite build --mode dev && node scripts/testing/e2e-server.mjs",
     "build": "vite build",
+    "build:mock": "vite build --mode mock",
     "preview": "vite preview",
     "check": "vue-tsc --noEmit --skipLibCheck",
     "type-check": "pnpm run check",

--- a/dc3-web/src/config/env/.env.mock
+++ b/dc3-web/src/config/env/.env.mock
@@ -1,3 +1,7 @@
 APP_API_PATH = "http://dc3-gateway"
 APP_API_PORT = "8000"
 APP_API_PREFIX = "/api"
+
+# Static demo build: ships a mock axios adapter, no backend needed.
+# The runtime gate in main.ts checks `import.meta.env.MODE === 'mock'`.
+APP_MOCK = "true"

--- a/dc3-web/src/main.ts
+++ b/dc3-web/src/main.ts
@@ -34,6 +34,20 @@ plugins(app);
 app.config.errorHandler = (err, _instance, info) => {
   logger.error('Global error:', err, 'Info:', info);
 };
-app.mount('#app');
+/**
+ * Static demo build: install a mock axios adapter before mounting so the app
+ * runs on fake data with no backend. Vite replaces import.meta.env.MODE with a
+ * build-time literal, so this branch (and the dynamically imported mock chunk)
+ * is dead-code eliminated from production builds.
+ */
+async function bootstrap(): Promise<void> {
+  if (import.meta.env.MODE === 'mock') {
+    const {setupMock} = await import('@/mock');
+    setupMock();
+  }
+  app.mount('#app');
+}
+
+void bootstrap();
 
 export default app;

--- a/dc3-web/src/mock/adapter.ts
+++ b/dc3-web/src/mock/adapter.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {AxiosAdapter, InternalAxiosRequestConfig} from 'axios';
+
+import {db} from './db';
+import {resolve} from './dispatch';
+import type {MockCtx} from './types';
+
+const safeParse = (raw: unknown): any => {
+  if (typeof raw !== 'string') return raw ?? {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Axios adapter that short-circuits every request to the mock dispatch table.
+ * Runs after the request interceptor (which injects auth headers) and feeds
+ * its response back through the response interceptor, so the rest of the app
+ * is unaware anything is mocked.
+ */
+export const createMockAdapter = (): AxiosAdapter => async (config: InternalAxiosRequestConfig) => {
+  const ctx: MockCtx = {
+    config,
+    url: (config.url || '').replace(/^\/+/, ''),
+    method: (config.method || 'get').toLowerCase(),
+    params: (config.params as Record<string, unknown>) || {},
+    body: safeParse(config.data),
+    db,
+  };
+  const handler = resolve(ctx);
+  return handler(ctx);
+};

--- a/dc3-web/src/mock/db.ts
+++ b/dc3-web/src/mock/db.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Mutable in-memory store. add/update/delete handlers mutate these arrays so a
+ * demo session reflects user actions without a backend. Seeded by the
+ * `seed/*` modules at adapter install time.
+ */
+export interface MockDb {
+  drivers: Record<string, unknown>[];
+  devices: Record<string, unknown>[];
+  profiles: Record<string, unknown>[];
+  points: Record<string, unknown>[];
+}
+
+export const db: MockDb = {
+  drivers: [],
+  devices: [],
+  profiles: [],
+  points: [],
+};

--- a/dc3-web/src/mock/dispatch.ts
+++ b/dc3-web/src/mock/dispatch.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {Handler, RouteRule} from './types';
+
+const exact = new Map<string, Handler>();
+const rules: RouteRule[] = [];
+let fallback: Handler | null = null;
+
+const entryKey = (method: string, url: string) => `${method} ${url}`;
+
+/**
+ * Register an exact URL match. Pass an array to bind multiple methods (e.g.
+ * get+post) to one handler.
+ */
+export function on(method: string | string[], url: string, handler: Handler): void {
+  const methods = Array.isArray(method) ? method : [method];
+  for (const m of methods) {
+    exact.set(entryKey(m.toLowerCase(), url), handler);
+  }
+}
+
+/** Register a regex-based rule for URL families that share a handler. */
+export function onRe(method: string, pattern: RegExp, handler: Handler): void {
+  rules.push({method: method.toLowerCase(), pattern, handler});
+}
+
+/** Register the last-resort handler used when no exact/regex rule matches. */
+export function setFallback(handler: Handler): void {
+  fallback = handler;
+}
+
+/** Resolve the handler for a request context, or the fallback. */
+export function resolve(ctx: {method: string; url: string}): Handler {
+  const byMethod = exact.get(entryKey(ctx.method, ctx.url));
+  if (byMethod) return byMethod;
+
+  for (const rule of rules) {
+    if ((!rule.method || rule.method === ctx.method) && rule.pattern.test(ctx.url)) {
+      return rule.handler;
+    }
+  }
+
+  // Should always be set before any request fires; this is a programming
+  // error if reached (setupMock forgot to call setFallback).
+  return (
+    fallback ??
+    (() => {
+      throw new Error('mock: fallback handler not registered');
+    })
+  );
+}

--- a/dc3-web/src/mock/handlers/auth.ts
+++ b/dc3-web/src/mock/handlers/auth.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from '../dispatch';
+import {ok, responseOf} from '../response';
+
+/**
+ * Mock the token endpoints so the real login/logout/change-password flow runs
+ * end-to-end. The auth store reads saltRes.data / tokenRes.data as plain
+ * strings, so we return R<string> envelopes.
+ */
+export function registerAuthHandlers(): void {
+  on('post', 'api/v3/auth/token/salt', (ctx) => responseOf(ctx.config, ok('mock-salt')));
+  on('post', 'api/v3/auth/token/generate', (ctx) => responseOf(ctx.config, ok('mock-token')));
+  on('post', 'api/v3/auth/token/check', (ctx) => responseOf(ctx.config, ok(true)));
+  on('post', 'api/v3/auth/token/cancel', (ctx) => responseOf(ctx.config, ok(true)));
+  on('post', 'api/v3/auth/token/change_password', (ctx) => responseOf(ctx.config, ok(true)));
+}

--- a/dc3-web/src/mock/handlers/fallback.ts
+++ b/dc3-web/src/mock/handlers/fallback.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {ok, okArray, okPage, responseOf} from '../response';
+import type {Handler} from '../types';
+
+/** Endpoints that return a flat array (not a PageResult) on success. */
+const ARRAY_SUFFIXES = /(_by_ids|_list_by_|list_tree|\/list)$/;
+
+/**
+ * Last-resort handler: shape the response by URL suffix so unregistered
+ * endpoints (most of the settings family, dashboard insight cards) degrade
+ * gracefully instead of surfacing server errors. Every business page wraps its
+ * calls in try/catch, so empty payloads keep the UI intact.
+ */
+export const fallbackHandler: Handler = (ctx) => {
+  const {url, params, body} = ctx;
+
+  if (url.endsWith('/list')) {
+    return responseOf(ctx.config, okPage([] as Record<string, unknown>[], 0));
+  }
+  if (ARRAY_SUFFIXES.test(url)) {
+    return responseOf(ctx.config, okArray([]));
+  }
+  if (url.endsWith('/get_by_id')) {
+    return responseOf(
+      ctx.config,
+      ok({id: String(params.id ?? '0'), name: 'Mock Entity', enableFlag: 'ENABLED'}),
+    );
+  }
+  if (/(\/(add|update|delete))$/.test(url)) {
+    const id = (body && (body.id ?? body.name)) || 'mock-id';
+    return responseOf(ctx.config, ok(String(id)));
+  }
+  if (url.endsWith('/count') || /get_count_by_/.test(url)) {
+    return responseOf(ctx.config, ok(0));
+  }
+  return responseOf(ctx.config, ok({}));
+};

--- a/dc3-web/src/mock/handlers/menu.ts
+++ b/dc3-web/src/mock/handlers/menu.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from '../dispatch';
+import {ok, okPage, responseOf} from '../response';
+import {menuTree} from '../seed/menuTree';
+import type {MenuNode} from '@/store/modules/menu';
+
+/** Flatten the tree into a flat list for the Menu settings table. */
+const flattenMenu = (nodes: MenuNode[]): MenuNode[] => {
+  const out: MenuNode[] = [];
+  const walk = (list: MenuNode[]) => {
+    for (const node of list) {
+      out.push(node);
+      if (node.children?.length) walk(node.children);
+    }
+  };
+  walk(nodes);
+  return out;
+};
+
+export function registerMenuHandlers(): void {
+  // Drives the router guard + Layout top nav. menu store takes res.data when
+  // it is an array, so we wrap the tree in an R envelope.
+  on('post', 'api/v3/auth/menu/list_tree', (ctx) => responseOf(ctx.config, ok(menuTree)));
+
+  // Menu management table (settingsMenu route).
+  on('post', 'api/v3/auth/menu/list', (ctx) =>
+    responseOf(ctx.config, okPage(flattenMenu(menuTree))),
+  );
+}

--- a/dc3-web/src/mock/index.ts
+++ b/dc3-web/src/mock/index.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import request from '@/config/axios';
+import {AUTH_HEADERS} from '@/config/constant/common';
+import {getStorage, setStorage} from '@/utils/storageUtil';
+
+import {createMockAdapter} from './adapter';
+import {setFallback} from './dispatch';
+import {registerAuthHandlers} from './handlers/auth';
+import {registerMenuHandlers} from './handlers/menu';
+import {fallbackHandler} from './handlers/fallback';
+
+let installed = false;
+
+/**
+ * Install the mock axios adapter and seed local auth so the static demo runs
+ * with zero backend. Called from main.ts only in mock builds; the dynamic
+ * import + build-time `import.meta.env.MODE` literal lets production builds
+ * drop this module entirely (verified via grep for the mock-token sentinel).
+ *
+ * Must run before `app.mount` so the adapter is in place ahead of the first
+ * router guard's menuStore.fetchTree() call.
+ */
+export function setupMock(): void {
+  if (installed) return;
+  installed = true;
+
+  setFallback(fallbackHandler);
+  registerAuthHandlers();
+  registerMenuHandlers();
+
+  request.defaults.adapter = createMockAdapter();
+
+  // Pre-seed auth so the first navigation lands on /home without a login click.
+  // The real login flow still works (registerAuthHandlers mocks the token
+  // endpoints), so logout → login → home is demoable too.
+  if (getStorage(AUTH_HEADERS.TENANT) == null) {
+    setStorage(AUTH_HEADERS.TENANT, 'default');
+    setStorage(AUTH_HEADERS.LOGIN, 'dc3');
+    setStorage(AUTH_HEADERS.TOKEN, {salt: 'mock-salt', token: 'mock-token'});
+  }
+}

--- a/dc3-web/src/mock/query.ts
+++ b/dc3-web/src/mock/query.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+interface PageInput {
+  current: number;
+  size: number;
+}
+
+/** Read pagination from a PageQuery body, defaulting to the usePagedList norms. */
+export const readPage = (body: any): PageInput => ({
+  current: Number(body?.page?.current ?? 1),
+  size: Number(body?.page?.size ?? 12),
+});
+
+/** Case-insensitive substring match, the common driver/device/profile/point search. */
+export const matches = (value: unknown, term: unknown): boolean => {
+  if (term === undefined || term === null || term === '') return true;
+  return String(value ?? '')
+    .toLowerCase()
+    .includes(String(term).toLowerCase());
+};
+
+/**
+ * Mimic server-side pagination + filtering. Returns the PageResult shape
+ * ({total, records}) that usePagedList reads from response.data.
+ */
+export const paginate = <T extends Record<string, any>>(
+  rows: T[],
+  body: any,
+  filter?: (row: T, body: any) => boolean,
+): {total: number; records: T[]} => {
+  const {current, size} = readPage(body);
+  const filtered = filter ? rows.filter((row) => filter(row, body)) : rows;
+  const start = (current - 1) * size;
+  return {total: filtered.length, records: filtered.slice(start, start + size)};
+};

--- a/dc3-web/src/mock/response.ts
+++ b/dc3-web/src/mock/response.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+
+/**
+ * Build a minimal AxiosResponse, mirroring the adapter contract verified in
+ * tests/unit/axios.test.ts. The response interceptor returns response.data
+ * verbatim when ok===true, so `data` here MUST be the full R envelope — never
+ * the inner payload.
+ */
+export const responseOf = (
+  config: InternalAxiosRequestConfig,
+  data: unknown,
+  status = 200,
+): AxiosResponse => ({
+  data,
+  status,
+  statusText: String(status),
+  headers: {},
+  config,
+  request: {},
+});
+
+/**
+ * R envelope constructors. The interceptor gates success on the `ok` boolean
+ * alone; code is always '0' and must never be 'R4031'/'R4032' (those trigger
+ * the change-password pass-through in the login flow).
+ */
+export const ok = <T = unknown>(data: T): R<T> => ({ok: true, code: '0', message: 'success', data});
+
+export const okPage = <T>(records: T[], total = records.length): R<{total: number; records: T[]}> =>
+  ok({total, records});
+
+export const okArray = <T>(data: T[]): R<T[]> => ok(data);

--- a/dc3-web/src/mock/seed/menuTree.ts
+++ b/dc3-web/src/mock/seed/menuTree.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {MenuNode} from '@/store/modules/menu';
+
+let seq = 0;
+
+interface NodeOpts {
+  url?: string;
+  icon?: string;
+  menuIndex?: number;
+  children?: MenuNode[];
+}
+
+const mk = (menuCode: string, opts: NodeOpts = {}): MenuNode => ({
+  id: ++seq,
+  parentMenuId: 0,
+  menuName: menuCode,
+  menuCode,
+  menuIndex: opts.menuIndex,
+  // resolveMenuTitle treats content.title as an i18n key, so `nav.<code>`
+  // localizes automatically for every route covered by Layout's nameMap /
+  // SETTINGS_TITLE_KEYS.
+  menuExt: {content: {title: `nav.${menuCode}`, url: opts.url, icon: opts.icon}},
+  enableFlag: 'ENABLED',
+  children: opts.children,
+});
+
+const leaf = (menuCode: string, url: string): MenuNode => mk(menuCode, {url});
+
+/**
+ * Full menu tree for the static demo. Covers every route name the router
+ * guard checks (top-level views + all settings leaves). Detail/edit routes
+ * resolve via ROUTE_MENU_ALIASES to their list sibling, so they need no node
+ * of their own. Group structure mirrors src/config/settingsNav.ts.
+ */
+export const menuTree: MenuNode[] = [
+  mk('home', {url: '/home', menuIndex: 1}),
+  mk('driver', {url: '/driver', icon: 'Promotion', menuIndex: 2}),
+  mk('profile', {url: '/profile', icon: 'List', menuIndex: 3}),
+  mk('device', {url: '/device', icon: 'Management', menuIndex: 4}),
+  mk('pointValue', {url: '/point_value', icon: 'Histogram', menuIndex: 5}),
+  mk('settings', {
+    menuIndex: 6,
+    children: [
+      mk('settingsIdentity', {
+        icon: 'User',
+        children: [
+          leaf('settingsUser', '/settings/user'),
+          leaf('settingsPrincipal', '/settings/principal'),
+          leaf('settingsTenantMembership', '/settings/tenant_membership'),
+          leaf('settingsLocalCredential', '/settings/local_credential'),
+          leaf('settingsServiceAccount', '/settings/service_account'),
+        ],
+      }),
+      mk('settingsAccess', {
+        icon: 'Stamp',
+        children: [
+          leaf('settingsRole', '/settings/role'),
+          leaf('settingsRolePrincipalBind', '/settings/role_principal_bind'),
+          leaf('settingsResource', '/settings/resource'),
+          leaf('settingsApi', '/settings/api'),
+          leaf('settingsMenu', '/settings/menu'),
+        ],
+      }),
+      mk('settingsModel', {
+        icon: 'Cpu',
+        children: [
+          leaf('settingsModelConfig', '/settings/model/config'),
+          leaf('settingsModelProvider', '/settings/model/provider'),
+        ],
+      }),
+      mk('settingsAlarm', {
+        icon: 'AlarmClock',
+        children: [
+          leaf('settingsAlarmRule', '/settings/alarm/rule'),
+          leaf('settingsAlarmNotify', '/settings/alarm/notify'),
+          leaf('settingsAlarmMessage', '/settings/alarm/message'),
+          leaf('settingsAlarmChannel', '/settings/alarm/channel'),
+          leaf('settingsAlarmBind', '/settings/alarm/bind'),
+          leaf('settingsAlarmOverview', '/settings/alarm/overview'),
+          leaf('settingsAlarmState', '/settings/alarm/state'),
+          leaf('settingsAlarmHistory', '/settings/alarm/history'),
+          leaf('settingsDriverAlarm', '/settings/alarm/driver'),
+          leaf('settingsDeviceAlarm', '/settings/alarm/device'),
+          leaf('settingsPointAlarm', '/settings/alarm/point'),
+        ],
+      }),
+      mk('settingsEventCommand', {
+        icon: 'Operation',
+        children: [
+          leaf('settingsEventHistory', '/settings/event/history'),
+          leaf('settingsCommandHistory', '/settings/command/history'),
+        ],
+      }),
+      mk('settingsAudit', {
+        icon: 'Files',
+        children: [
+          leaf('settingsIdentityAudit', '/settings/identity_audit'),
+          leaf('settingsMcpAudit', '/settings/mcp_audit'),
+        ],
+      }),
+      mk('settingsIntegration', {
+        icon: 'Share',
+        children: [
+          leaf('settingsMcpServer', '/settings/mcp'),
+          leaf('settingsMcpConnection', '/settings/mcp/connection'),
+          leaf('settingsMcpClient', '/settings/mcp/client'),
+          leaf('settingsMcpTool', '/settings/mcp/tool'),
+        ],
+      }),
+      mk('settingsSystem', {
+        icon: 'Tools',
+        children: [
+          leaf('settingsGroup', '/settings/group'),
+          leaf('settingsLabel', '/settings/label'),
+          leaf('settingsAbout', '/settings/about'),
+        ],
+      }),
+    ],
+  }),
+];

--- a/dc3-web/src/mock/types.ts
+++ b/dc3-web/src/mock/types.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+
+import type {MockDb} from './db';
+
+export interface MockCtx {
+  /** Original axios config — needed to build the AxiosResponse. */
+  config: InternalAxiosRequestConfig;
+  /** Normalized URL with no leading slash (e.g. `api/v3/manager/device/list`). */
+  url: string;
+  /** Lowercased HTTP method. */
+  method: string;
+  /** Query params (GET) or empty object. */
+  params: Record<string, unknown>;
+  /** Parsed request body (POST) or empty object. */
+  body: any;
+  /** Mutable in-memory store shared across handlers. */
+  db: MockDb;
+}
+
+export type Handler = (ctx: MockCtx) => AxiosResponse | Promise<AxiosResponse>;
+
+export interface RouteRule {
+  method?: string;
+  pattern: RegExp;
+  handler: Handler;
+}

--- a/dc3-web/vite.config.ts
+++ b/dc3-web/vite.config.ts
@@ -108,7 +108,9 @@ export default (configEnv: ConfigEnv) => {
       outDir: 'dist',
       chunkSizeWarningLimit: 1500,
       // minify defaults to rolldown in Vite 8
-      sourcemap: configEnv.mode === 'production' ? false : true,
+      // Mock builds are deployed publicly as a static demo — drop sourcemaps
+      // to shrink the bundle and avoid exposing source.
+      sourcemap: configEnv.mode === 'production' || configEnv.mode === 'mock' ? false : true,
       reportCompressedSize: false,
       cssCodeSplit: true,
       rollupOptions: {output},


### PR DESCRIPTION
## Summary

Targeted defects in the `dc3-api` gRPC contract layer + their full call chains. **Breaking contract changes** — all center/driver/gateway services must be rebuilt and redeployed together.

| Commit | Defect | Change |
|---|---|---|
| `cede51ade` | #2 | `enable_flag` comment was inverted vs `EnableFlagEnum` (ENABLE=0); fixed + documented epoch-seconds time unit |
| `08a833683` | #5 / #6 | Point-value history now carries `create_time` end-to-end (was `List<String>`, dropping the timestamp the DB already had); `GrpcR.ok` and `McpIntrospectDTO.active` are now `optional bool` |
| `a194ba4bd` | #1 (security) | JWT signing key unified to the single configured `securityKey` (HS256); per-principal `salt` removed from the JWT path; `salt`/`password` dropped from `GrpcLoginQuery`. Login-handshake salt (POST /token/salt) unchanged |
| `1da770c5d` | #3 (partial) | MCP authorize `decision` is now `GrpcMcpDecision` enum (AUTHORIZED/CONFIRM_REQUIRED/REJECTED) instead of free-form string |

## Verification

Per-module `mvn test` green: public 287, auth 91, gateway 20, data 265, agentic 213, facade-grpc + facade-local-data all pass.

## Not in this PR (follow-up)

- #3 remaining string fields (`risk_level`, `status`, `grant_type`, `principal_type`) — wider/lowercase value sets, separate change.
- #4 `GrpcR` → gRPC `status` error model — largest scope (20 servers × most methods + all callers), separate PR.

## ⚠️ Breaking

`dc3-api` is a deployed Maven artifact. These contract changes require every dependent service to regenerate stubs and redeploy in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)