### PR TITLE
refactor(api): type MCP risk_level as proto enum

### DIFF
--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
@@ -113,11 +113,19 @@ message GrpcMcpToolAnnotationsDTO {
   bool open_world_hint = 4;
 }
 
+// MCP tool risk level. Names match McpRiskLevelEnum values (LOW/MEDIUM/HIGH).
+enum GrpcMcpRiskLevel {
+  MCP_RISK_LEVEL_UNSPECIFIED = 0;
+  LOW = 1;
+  MEDIUM = 2;
+  HIGH = 3;
+}
+
 // MCP tool metadata.
 message GrpcMcpToolMetadataDTO {
   string tool_id = 1;
   string permission_code = 2;
-  string risk_level = 3;
+  GrpcMcpRiskLevel risk_level = 3;
 }
 
 // Visible tool resolve request.
@@ -143,7 +151,7 @@ message GrpcMcpToolResolveDTO {
   string tool_id = 1;
   string tool_name = 2;
   string permission_code = 3;
-  string risk_level = 4;
+  GrpcMcpRiskLevel risk_level = 4;
   string service_name = 5;
   string api_path = 6;
   string http_method = 7;
@@ -188,7 +196,7 @@ message GrpcMcpToolAuthorizeDTO {
   // Human readable reason or confirmation prompt.
   string message = 3;
   // Resolved tool risk level.
-  string risk_level = 4;
+  GrpcMcpRiskLevel risk_level = 4;
 }
 
 // MCP audit insert command.
@@ -202,7 +210,7 @@ message GrpcMcpAuditCommand {
   string tool_id = 7;
   string tool_name = 8;
   string permission_code = 9;
-  string risk_level = 10;
+  GrpcMcpRiskLevel risk_level = 10;
   string confirm_id = 11;
   string idempotency_key = 12;
   string argument_digest = 13;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
@@ -243,7 +243,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
         return GrpcMcpToolMetadataDTO.newBuilder()
                 .setToolId(StringUtils.defaultString(source.getToolId()))
                 .setPermissionCode(StringUtils.defaultString(source.getPermissionCode()))
-                .setRiskLevel(StringUtils.defaultString(source.getRiskLevel()))
+                .setRiskLevel(toGrpcRiskLevel(source.getRiskLevel()))
                 .build();
     }
 
@@ -258,7 +258,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .setToolId(StringUtils.defaultString(source.getToolId()))
                 .setToolName(StringUtils.defaultString(source.getToolName()))
                 .setPermissionCode(StringUtils.defaultString(source.getPermissionCode()))
-                .setRiskLevel(StringUtils.defaultString(source.getRiskLevel()))
+                .setRiskLevel(toGrpcRiskLevel(source.getRiskLevel()))
                 .setServiceName(StringUtils.defaultString(source.getServiceName()))
                 .setApiPath(StringUtils.defaultString(source.getApiPath()))
                 .setHttpMethod(StringUtils.defaultString(source.getHttpMethod()))
@@ -276,7 +276,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .setDecision(toGrpcDecision(source.getDecision()))
                 .setConfirmId(StringUtils.defaultString(source.getConfirmId()))
                 .setMessage(StringUtils.defaultString(source.getMessage()))
-                .setRiskLevel(StringUtils.defaultString(source.getRiskLevel()))
+                .setRiskLevel(toGrpcRiskLevel(source.getRiskLevel()))
                 .build();
     }
 
@@ -285,6 +285,14 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
             return GrpcMcpDecision.valueOf(StringUtils.defaultIfBlank(value, ""));
         } catch (IllegalArgumentException e) {
             return GrpcMcpDecision.MCP_DECISION_UNSPECIFIED;
+        }
+    }
+
+    private GrpcMcpRiskLevel toGrpcRiskLevel(String value) {
+        try {
+            return GrpcMcpRiskLevel.valueOf(StringUtils.defaultIfBlank(value, ""));
+        } catch (IllegalArgumentException e) {
+            return GrpcMcpRiskLevel.MCP_RISK_LEVEL_UNSPECIFIED;
         }
     }
 
@@ -305,7 +313,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .toolId(source.getToolId())
                 .toolName(source.getToolName())
                 .permissionCode(source.getPermissionCode())
-                .riskLevel(source.getRiskLevel())
+                .riskLevel(source.getRiskLevel().name())
                 .confirmId(source.getConfirmId())
                 .idempotencyKey(source.getIdempotencyKey())
                 .argumentDigest(source.getArgumentDigest())

--- a/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/grpc/McpRuntimeServerTest.java
+++ b/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/grpc/McpRuntimeServerTest.java
@@ -18,6 +18,7 @@
 package io.github.pnoker.common.auth.grpc;
 
 import io.github.pnoker.api.center.auth.GrpcMcpAuditCommand;
+import io.github.pnoker.api.center.auth.GrpcMcpRiskLevel;
 import io.github.pnoker.api.center.auth.GrpcMcpIntrospectRequest;
 import io.github.pnoker.api.center.auth.GrpcMcpToolListRequest;
 import io.github.pnoker.api.center.auth.GrpcMcpToolResolveRequest;
@@ -163,7 +164,7 @@ class McpRuntimeServerTest {
                 .build());
 
         assertThat(response.getResult().getOk()).isTrue();
-        assertThat(response.getData().getRiskLevel()).isEqualTo("HIGH");
+        assertThat(response.getData().getRiskLevel()).isEqualTo(GrpcMcpRiskLevel.HIGH);
         assertThat(response.getData().getServiceName()).isEqualTo("dc3-center-manager");
         assertThat(response.getData().getApiPath()).isEqualTo("/api/v3/manager/device/restart");
     }

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
@@ -126,7 +126,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .decision(source.getDecision().name())
                 .confirmId(source.getConfirmId())
                 .message(source.getMessage())
-                .riskLevel(source.getRiskLevel())
+                .riskLevel(source.getRiskLevel().name())
                 .build();
     }
 
@@ -175,7 +175,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
         return McpToolDefinitionDTO.Metadata.builder()
                 .toolId(source.getToolId())
                 .permissionCode(source.getPermissionCode())
-                .riskLevel(source.getRiskLevel())
+                .riskLevel(source.getRiskLevel().name())
                 .build();
     }
 
@@ -184,7 +184,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .toolId(source.getToolId())
                 .toolName(source.getToolName())
                 .permissionCode(source.getPermissionCode())
-                .riskLevel(source.getRiskLevel())
+                .riskLevel(source.getRiskLevel().name())
                 .serviceName(source.getServiceName())
                 .apiPath(source.getApiPath())
                 .httpMethod(source.getHttpMethod())
@@ -203,7 +203,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .setToolId(StringUtils.defaultString(source.getToolId()))
                 .setToolName(StringUtils.defaultString(source.getToolName()))
                 .setPermissionCode(StringUtils.defaultString(source.getPermissionCode()))
-                .setRiskLevel(StringUtils.defaultString(source.getRiskLevel()))
+                .setRiskLevel(toGrpcRiskLevel(source.getRiskLevel()))
                 .setConfirmId(StringUtils.defaultString(source.getConfirmId()))
                 .setIdempotencyKey(StringUtils.defaultString(source.getIdempotencyKey()))
                 .setArgumentDigest(StringUtils.defaultString(source.getArgumentDigest()))
@@ -227,6 +227,14 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
     private void requireOk(String operation, GrpcR result) {
         if (!result.getOk()) {
             throw new ServiceException(operation + " failed: [" + result.getCode() + "] " + result.getMessage());
+        }
+    }
+
+    private GrpcMcpRiskLevel toGrpcRiskLevel(String value) {
+        try {
+            return GrpcMcpRiskLevel.valueOf(StringUtils.defaultIfBlank(value, ""));
+        } catch (IllegalArgumentException e) {
+            return GrpcMcpRiskLevel.MCP_RISK_LEVEL_UNSPECIFIED;
         }
     }
 


### PR DESCRIPTION
Continues the string→enum cleanup from PR #193 (which did the `decision` field). `risk_level` is now `GrpcMcpRiskLevel` (LOW/MEDIUM/HIGH) across the 4 MCP proto messages that carried it. BO/DB stay string; conversion is at the proto boundary (Server + Facade). auth + facade-grpc tests green (91 passed). Breaking contract change — services must regenerate stubs + redeploy together. 🤖 Generated with [Claude Code](https://claude.com/claude-code)