### PR TITLE
refactor(api): type MCP principal_type as proto enum

### DIFF
--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
@@ -70,13 +70,21 @@ message GrpcMcpIntrospectDTO {
   int64 iat = 7;
   int64 tenant_id = 8;
   int64 principal_id = 9;
-  string principal_type = 10;
+  GrpcMcpPrincipalType principal_type = 10;
   string principal_name = 11;
   string display_name = 12;
   string client_id = 13;
   int64 mcp_connection_id = 14;
   string grant_type = 15;
   string scope = 16;
+}
+
+// MCP principal classification. Names match PrincipalTypeEnum values.
+enum GrpcMcpPrincipalType {
+  MCP_PRINCIPAL_TYPE_UNSPECIFIED = 0;
+  USER = 1;
+  SERVICE_ACCOUNT = 2;
+  SYSTEM = 3;
 }
 
 // Visible tool list request.
@@ -204,7 +212,7 @@ message GrpcMcpAuditCommand {
   string trace_id = 1;
   int64 tenant_id = 2;
   int64 principal_id = 3;
-  string principal_type = 4;
+  GrpcMcpPrincipalType principal_type = 4;
   string client_id = 5;
   int64 connection_id = 6;
   string tool_id = 7;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
@@ -185,7 +185,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .setIat(source.getIat() == null ? 0 : source.getIat())
                 .setTenantId(source.getTenantId() == null ? 0 : source.getTenantId())
                 .setPrincipalId(source.getPrincipalId() == null ? 0 : source.getPrincipalId())
-                .setPrincipalType(StringUtils.defaultString(source.getPrincipalType()))
+                .setPrincipalType(toGrpcPrincipalType(source.getPrincipalType()))
                 .setPrincipalName(StringUtils.defaultString(source.getPrincipalName()))
                 .setDisplayName(StringUtils.defaultString(source.getDisplayName()))
                 .setClientId(StringUtils.defaultString(source.getClientId()))
@@ -296,6 +296,14 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
         }
     }
 
+    private GrpcMcpPrincipalType toGrpcPrincipalType(String value) {
+        try {
+            return GrpcMcpPrincipalType.valueOf(StringUtils.defaultIfBlank(value, ""));
+        } catch (IllegalArgumentException e) {
+            return GrpcMcpPrincipalType.MCP_PRINCIPAL_TYPE_UNSPECIFIED;
+        }
+    }
+
     /**
      * Convert a gRPC audit command to its DTO form.
      *
@@ -307,7 +315,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .traceId(source.getTraceId())
                 .tenantId(source.getTenantId())
                 .principalId(source.getPrincipalId())
-                .principalType(source.getPrincipalType())
+                .principalType(source.getPrincipalType().name())
                 .clientId(source.getClientId())
                 .connectionId(source.getConnectionId())
                 .toolId(source.getToolId())

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
@@ -141,7 +141,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .iat(zeroToNull(source.getIat()))
                 .tenantId(zeroToNull(source.getTenantId()))
                 .principalId(zeroToNull(source.getPrincipalId()))
-                .principalType(source.getPrincipalType())
+                .principalType(source.getPrincipalType().name())
                 .principalName(source.getPrincipalName())
                 .displayName(source.getDisplayName())
                 .clientId(source.getClientId())
@@ -197,7 +197,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .setTraceId(StringUtils.defaultString(source.getTraceId()))
                 .setTenantId(value(source.getTenantId()))
                 .setPrincipalId(value(source.getPrincipalId()))
-                .setPrincipalType(StringUtils.defaultString(source.getPrincipalType()))
+                .setPrincipalType(toGrpcPrincipalType(source.getPrincipalType()))
                 .setClientId(StringUtils.defaultString(source.getClientId()))
                 .setConnectionId(value(source.getConnectionId()))
                 .setToolId(StringUtils.defaultString(source.getToolId()))
@@ -235,6 +235,14 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
             return GrpcMcpRiskLevel.valueOf(StringUtils.defaultIfBlank(value, ""));
         } catch (IllegalArgumentException e) {
             return GrpcMcpRiskLevel.MCP_RISK_LEVEL_UNSPECIFIED;
+        }
+    }
+
+    private GrpcMcpPrincipalType toGrpcPrincipalType(String value) {
+        try {
+            return GrpcMcpPrincipalType.valueOf(StringUtils.defaultIfBlank(value, ""));
+        } catch (IllegalArgumentException e) {
+            return GrpcMcpPrincipalType.MCP_PRINCIPAL_TYPE_UNSPECIFIED;
         }
     }
 


### PR DESCRIPTION
Continues the string→enum cleanup (#193 decision, #195 risk_level). `principal_type` is now `GrpcMcpPrincipalType` (USER/SERVICE_ACCOUNT/SYSTEM) in GrpcMcpIntrospectDTO + GrpcMcpAuditCommand. BO/gateway/HTTP header stay string; conversion at proto boundary only. auth + facade-grpc + gateway tests green (91 passed), zero test changes needed. Breaking contract change — regenerate stubs + redeploy together. 🤖 Generated with [Claude Code](https://claude.com/claude-code)