### PR TITLE
refactor(api): type MCP audit status as proto enum

### DIFF
--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
@@ -207,6 +207,16 @@ message GrpcMcpToolAuthorizeDTO {
   GrpcMcpRiskLevel risk_level = 4;
 }
 
+// MCP audit outcome. Names match McpAuditStatusEnum values.
+enum GrpcMcpAuditStatus {
+  MCP_AUDIT_STATUS_UNSPECIFIED = 0;
+  SUCCESS = 1;
+  DENIED = 2;
+  POLICY_DENIED = 3;
+  ERROR = 4;
+  UNKNOWN = 5;
+}
+
 // MCP audit insert command.
 message GrpcMcpAuditCommand {
   string trace_id = 1;
@@ -222,7 +232,7 @@ message GrpcMcpAuditCommand {
   string confirm_id = 11;
   string idempotency_key = 12;
   string argument_digest = 13;
-  string status = 14;
+  GrpcMcpAuditStatus status = 14;
   string error_code = 15;
   int64 duration_ms = 16;
   string client_name = 17;

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
@@ -325,7 +325,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .confirmId(source.getConfirmId())
                 .idempotencyKey(source.getIdempotencyKey())
                 .argumentDigest(source.getArgumentDigest())
-                .status(source.getStatus())
+                .status(source.getStatus().name())
                 .errorCode(source.getErrorCode())
                 .durationMs(source.getDurationMs())
                 .clientName(source.getClientName())

--- a/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/grpc/McpRuntimeServerTest.java
+++ b/dc3-common/dc3-common-auth/src/test/java/io/github/pnoker/common/auth/grpc/McpRuntimeServerTest.java
@@ -18,6 +18,7 @@
 package io.github.pnoker.common.auth.grpc;
 
 import io.github.pnoker.api.center.auth.GrpcMcpAuditCommand;
+import io.github.pnoker.api.center.auth.GrpcMcpAuditStatus;
 import io.github.pnoker.api.center.auth.GrpcMcpRiskLevel;
 import io.github.pnoker.api.center.auth.GrpcMcpIntrospectRequest;
 import io.github.pnoker.api.center.auth.GrpcMcpToolListRequest;
@@ -178,7 +179,7 @@ class McpRuntimeServerTest {
                 .setConnectionId(300L)
                 .setToolId("tool-1")
                 .setToolName("restart_device")
-                .setStatus("SUCCESS")
+                .setStatus(GrpcMcpAuditStatus.SUCCESS)
                 .setDurationMs(20L)
                 .build());
 

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
@@ -207,7 +207,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .setConfirmId(StringUtils.defaultString(source.getConfirmId()))
                 .setIdempotencyKey(StringUtils.defaultString(source.getIdempotencyKey()))
                 .setArgumentDigest(StringUtils.defaultString(source.getArgumentDigest()))
-                .setStatus(StringUtils.defaultString(source.getStatus()))
+                .setStatus(toGrpcAuditStatus(source.getStatus()))
                 .setErrorCode(StringUtils.defaultString(source.getErrorCode()))
                 .setDurationMs(value(source.getDurationMs()))
                 .setClientName(StringUtils.defaultString(source.getClientName()))
@@ -243,6 +243,14 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
             return GrpcMcpPrincipalType.valueOf(StringUtils.defaultIfBlank(value, ""));
         } catch (IllegalArgumentException e) {
             return GrpcMcpPrincipalType.MCP_PRINCIPAL_TYPE_UNSPECIFIED;
+        }
+    }
+
+    private GrpcMcpAuditStatus toGrpcAuditStatus(String value) {
+        try {
+            return GrpcMcpAuditStatus.valueOf(StringUtils.defaultIfBlank(value, ""));
+        } catch (IllegalArgumentException e) {
+            return GrpcMcpAuditStatus.MCP_AUDIT_STATUS_UNSPECIFIED;
         }
     }
 


### PR DESCRIPTION
Continues string→enum cleanup (#193 decision, #195 risk_level, #196 principal_type). `status` in GrpcMcpAuditCommand is now `GrpcMcpAuditStatus` (SUCCESS/DENIED/POLICY_DENIED/ERROR/UNKNOWN). BO/DB stay string; conversion at proto boundary. auth + facade-grpc tests green (91 passed). Breaking contract change — regenerate stubs + redeploy together. 🤖 Generated with [Claude Code](https://claude.com/claude-code)