### PR TITLE
refactor(api): type OAuth grant_type as proto enum

### DIFF
--- a/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
+++ b/dc3-api/dc3-api-auth/src/main/protobuf/api/common/auth/mcp_runtime.proto
@@ -75,7 +75,7 @@ message GrpcMcpIntrospectDTO {
   string display_name = 12;
   string client_id = 13;
   int64 mcp_connection_id = 14;
-  string grant_type = 15;
+  GrpcOAuthGrantType grant_type = 15;
   string scope = 16;
 }
 
@@ -85,6 +85,16 @@ enum GrpcMcpPrincipalType {
   USER = 1;
   SERVICE_ACCOUNT = 2;
   SYSTEM = 3;
+}
+
+// OAuth grant type. Enum names are upper-case (Java enum constants must be);
+// the on-the-wire value is the enum name, which the boundary converts
+// to/from the lowercase OAuth spec form (authorization_code etc.).
+enum GrpcOAuthGrantType {
+  GRPC_OAUTH_GRANT_TYPE_UNSPECIFIED = 0;
+  AUTHORIZATION_CODE = 1;
+  CLIENT_CREDENTIALS = 2;
+  REFRESH_TOKEN = 3;
 }
 
 // Visible tool list request.

--- a/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
+++ b/dc3-common/dc3-common-auth/src/main/java/io/github/pnoker/common/auth/grpc/McpRuntimeServer.java
@@ -190,7 +190,7 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
                 .setDisplayName(StringUtils.defaultString(source.getDisplayName()))
                 .setClientId(StringUtils.defaultString(source.getClientId()))
                 .setMcpConnectionId(source.getMcpConnectionId() == null ? 0 : source.getMcpConnectionId())
-                .setGrantType(StringUtils.defaultString(source.getGrantType()))
+                .setGrantType(toGrpcGrantType(source.getGrantType()))
                 .setScope(StringUtils.defaultString(source.getScope()))
                 .build();
     }
@@ -301,6 +301,14 @@ public class McpRuntimeServer extends McpRuntimeApiGrpc.McpRuntimeApiImplBase {
             return GrpcMcpPrincipalType.valueOf(StringUtils.defaultIfBlank(value, ""));
         } catch (IllegalArgumentException e) {
             return GrpcMcpPrincipalType.MCP_PRINCIPAL_TYPE_UNSPECIFIED;
+        }
+    }
+
+    private GrpcOAuthGrantType toGrpcGrantType(String value) {
+        try {
+            return GrpcOAuthGrantType.valueOf(StringUtils.defaultIfBlank(value, "").toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return GrpcOAuthGrantType.GRPC_OAUTH_GRANT_TYPE_UNSPECIFIED;
         }
     }
 

--- a/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
+++ b/dc3-common/dc3-common-facade/dc3-common-facade-grpc/src/main/java/io/github/pnoker/common/facade/grpc/McpRuntimeGrpcFacade.java
@@ -146,7 +146,7 @@ public class McpRuntimeGrpcFacade implements McpRuntimeFacade {
                 .displayName(source.getDisplayName())
                 .clientId(source.getClientId())
                 .mcpConnectionId(zeroToNull(source.getMcpConnectionId()))
-                .grantType(source.getGrantType())
+                .grantType(source.getGrantType().name().toLowerCase())
                 .scope(source.getScope())
                 .build();
     }


### PR DESCRIPTION
Completes the string→enum cleanup (#193 decision, #195 risk_level, #196 principal_type, #197 status). `grant_type` in GrpcMcpIntrospectDTO is now `GrpcOAuthGrantType`. Enum names upper-case; boundary converts to/from lowercase OAuth spec form. BO/DB/OAuth form param stay lowercase string — zero test changes. auth + facade-grpc tests green (91 passed). Breaking contract change — regenerate stubs + redeploy together. 🤖 Generated with [Claude Code](https://claude.com/claude-code)