### PR TITLE
feat(web): realistic mock demo + login-page entry and header icon fixes

### DIFF
--- a/dc3-web/src/components/layout/Layout.vue
+++ b/dc3-web/src/components/layout/Layout.vue
@@ -42,6 +42,9 @@
                 :key="`menu-child-${child.id}`"
                 :index="child.menuExt?.content?.url || `/${child.menuCode}`"
               >
+                <el-icon v-if="child.menuExt?.content?.icon">
+                  <component :is="child.menuExt.content.icon"/>
+                </el-icon>
                 {{ resolveMenuTitle(child) }}
               </el-menu-item>
             </el-sub-menu>

--- a/dc3-web/src/config/types/agentic.ts
+++ b/dc3-web/src/config/types/agentic.ts
@@ -36,6 +36,7 @@ export interface AgenticProvider {
   remark?: string;
   createTime?: string;
   operateTime?: string;
+  [key: string]: unknown;
 }
 
 export interface AgenticModelConfig {
@@ -63,6 +64,7 @@ export interface AgenticModelConfig {
   remark?: string;
   createTime?: string;
   operateTime?: string;
+  [key: string]: unknown;
 }
 
 export interface AgenticSession {
@@ -71,6 +73,7 @@ export interface AgenticSession {
   sessionExt?: AgenticSessionExt;
   createTime?: string;
   operateTime?: string;
+  [key: string]: unknown;
 }
 
 export interface AgenticSessionExt {
@@ -94,6 +97,7 @@ export interface AgenticMessage {
   reasoning?: string;
   finishReason?: string;
   createTime?: string;
+  [key: string]: unknown;
 }
 
 export interface AgenticMessageContent {

--- a/dc3-web/src/config/types/common.ts
+++ b/dc3-web/src/config/types/common.ts
@@ -36,6 +36,8 @@ export interface Attribute {
   remark?: string;
   attributeExt?: Record<string, unknown>;
   enableFlag?: string;
+
+  [key: string]: unknown;
 }
 
 /** Dictionary item */

--- a/dc3-web/src/main.ts
+++ b/dc3-web/src/main.ts
@@ -22,20 +22,8 @@ import plugins from '@/config/plugins/index';
 import router from '@/config/router';
 import {createApp} from 'vue';
 import {logger} from '@/utils/log';
-import {AUTH_HEADERS} from '@/config/constant/common';
-import {setStorage} from '@/utils/storageUtil';
 
 import '@/styles/global.scss'; // config app
-
-// Pre-seed auth in mock mode BEFORE the router is installed. Vue Router's
-// initial navigation runs as a microtask, ahead of the async mock-chunk
-// import in bootstrap() below; without this the guard sees empty storage and
-// bounces every route to /login on first load.
-if (import.meta.env.MODE === 'mock') {
-  setStorage(AUTH_HEADERS.TENANT, 'default');
-  setStorage(AUTH_HEADERS.LOGIN, 'dc3');
-  setStorage(AUTH_HEADERS.TOKEN, {salt: 'mock-salt', token: 'mock-token'});
-}
 
 // config app
 const app = createApp(App);

--- a/dc3-web/src/mock/crud.ts
+++ b/dc3-web/src/mock/crud.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from './dispatch';
+import {matches, paginate} from './query';
+import {ok, responseOf} from './response';
+import {db} from './db';
+import type {MockDb} from './db';
+import type {MockCtx} from './types';
+
+/** Format the current time as `YYYY-MM-DD HH:mm:ss` so demo rows read naturally. */
+export const stamp = (): string => {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+};
+
+/** Monotonic id for rows created at runtime — starts above the seed id space. */
+let counter = 90001;
+export const newId = (): string => String(counter++);
+
+export interface CrudSpec {
+  /** Base URL without leading slash, e.g. `api/v3/auth/role`. */
+  baseUrl: string;
+  /** Mutable collection in `db` backing this entity. */
+  collection: keyof MockDb;
+  /** Body fields matched as case-insensitive substrings in `/list`. */
+  search?: string[];
+  /** Body fields matched by equality in `/list` (defaults to `['enableFlag']`). */
+  exact?: string[];
+  /** Register `/enable` and `/disable` toggles (principal/serviceAccount). */
+  enable?: boolean;
+}
+
+const compileFilter =
+  (search: string[], exact: string[]) =>
+  (row: Record<string, unknown>, body: any): boolean =>
+    search.every((f) => matches(row[f], body?.[f])) &&
+    exact.every((f) => {
+      const v = body?.[f];
+      return v === undefined || v === null || v === '' || v === 'ALL' || String(row[f]) === String(v);
+    });
+
+/**
+ * Register the standard CRUD endpoints for an entity against the mutable in-memory
+ * `db`. add/update/delete/enable/disable mutate the collection so a demo session
+ * reflects user actions; `/list` re-reads the (now mutated) collection each call.
+ *
+ * Registered: POST /list, GET /get_by_id, POST /add, POST /update, POST /delete,
+ * (optional) POST /enable, POST /disable.
+ *
+ * Out of scope (entity-specific shapes): /list_by_ids, /list_tree, join queries,
+ * history — register those separately next to this call.
+ */
+export function registerCrud(spec: CrudSpec): void {
+  const {baseUrl, collection, search = [], exact = ['enableFlag'], enable = false} = spec;
+  const rows = (): Record<string, unknown>[] => db[collection] as Record<string, unknown>[];
+  const filter = compileFilter(search, exact);
+  const findById = (id: unknown) => rows().find((r) => String(r.id) === String(id));
+
+  on('post', `${baseUrl}/list`, (ctx) => responseOf(ctx.config, ok(paginate(rows(), ctx.body, filter))));
+  on('get', `${baseUrl}/get_by_id`, (ctx) =>
+    responseOf(ctx.config, ok(findById(ctx.params.id) ?? rows()[0] ?? {})),
+  );
+  on('post', `${baseUrl}/add`, (ctx) => {
+    const row: Record<string, unknown> = {...ctx.body, id: newId(), createTime: stamp(), operateTime: stamp()};
+    rows().push(row);
+    return responseOf(ctx.config, ok(String(row.id)));
+  });
+  on('post', `${baseUrl}/update`, (ctx) => {
+    const i = rows().findIndex((r) => String(r.id) === String(ctx.body?.id));
+    if (i >= 0) rows()[i] = {...rows()[i], ...ctx.body, operateTime: stamp()};
+    return responseOf(ctx.config, ok(String(ctx.body?.id ?? '')));
+  });
+  on('post', `${baseUrl}/delete`, (ctx) => {
+    const id = ctx.params.id;
+    const i = rows().findIndex((r) => String(r.id) === String(id));
+    if (i >= 0) rows().splice(i, 1);
+    return responseOf(ctx.config, ok(String(id)));
+  });
+  if (enable) {
+    const toggle = (flag: string) => (ctx: MockCtx) => {
+      const row = findById(ctx.params.id);
+      if (row) row.enableFlag = flag;
+      return responseOf(ctx.config, ok(String(ctx.params.id)));
+    };
+    on('post', `${baseUrl}/enable`, toggle('ENABLE'));
+    on('post', `${baseUrl}/disable`, toggle('DISABLE'));
+  }
+}

--- a/dc3-web/src/mock/db.ts
+++ b/dc3-web/src/mock/db.ts
@@ -16,6 +16,48 @@
  */
 
 import {devices, drivers, points, profiles} from './seed/entities';
+import {
+  users,
+  roles,
+  rolePrincipalBinds,
+  roleResourceBinds,
+  principals,
+  serviceAccounts,
+  tenantMemberships,
+  identityAudits,
+  localCredentials,
+} from './seed/auth';
+import {
+  groups,
+  labels,
+  apis,
+  resources,
+  commands,
+  commandParams,
+  events,
+  eventParams,
+  attributes,
+  attributeConfigs,
+} from './seed/manager';
+import {
+  alarmRules,
+  alarmNotifies,
+  alarmMessages,
+  alarmChannels,
+  alarmChannelBinds,
+  alarmRuleStates,
+  alarmHistories,
+} from './seed/data';
+import {
+  agenticProviders,
+  agenticModelConfigs,
+  agenticSessions,
+  agenticMessages,
+  mcpClients,
+  mcpConnections,
+  mcpTools,
+  mcpAudits,
+} from './seed/agentic';
 
 /**
  * Mutable in-memory store. add/update/delete handlers mutate these arrays so a
@@ -27,11 +69,81 @@ export interface MockDb {
   devices: Record<string, unknown>[];
   profiles: Record<string, unknown>[];
   points: Record<string, unknown>[];
+  users: Record<string, unknown>[];
+  roles: Record<string, unknown>[];
+  rolePrincipalBinds: Record<string, unknown>[];
+  roleResourceBinds: Record<string, unknown>[];
+  principals: Record<string, unknown>[];
+  serviceAccounts: Record<string, unknown>[];
+  tenantMemberships: Record<string, unknown>[];
+  identityAudits: Record<string, unknown>[];
+  localCredentials: Record<string, unknown>[];
+  groups: Record<string, unknown>[];
+  labels: Record<string, unknown>[];
+  apis: Record<string, unknown>[];
+  resources: Record<string, unknown>[];
+  commands: Record<string, unknown>[];
+  commandParams: Record<string, unknown>[];
+  events: Record<string, unknown>[];
+  eventParams: Record<string, unknown>[];
+  attributes: Record<string, unknown>[];
+  attributeConfigs: Record<string, unknown>[];
+  alarmRules: Record<string, unknown>[];
+  alarmNotifies: Record<string, unknown>[];
+  alarmMessages: Record<string, unknown>[];
+  alarmChannels: Record<string, unknown>[];
+  alarmChannelBinds: Record<string, unknown>[];
+  alarmRuleStates: Record<string, unknown>[];
+  alarmHistories: Record<string, unknown>[];
+  agenticProviders: Record<string, unknown>[];
+  agenticModelConfigs: Record<string, unknown>[];
+  agenticSessions: Record<string, unknown>[];
+  agenticMessages: Record<string, unknown>[];
+  mcpClients: Record<string, unknown>[];
+  mcpConnections: Record<string, unknown>[];
+  mcpTools: Record<string, unknown>[];
+  mcpAudits: Record<string, unknown>[];
 }
 
+const copy = <T>(rows: T[]): T[] => rows.map((r) => ({...r}));
+
 export const db: MockDb = {
-  drivers: [...drivers],
-  devices: [...devices],
-  profiles: [...profiles],
-  points: [...points],
+  drivers: copy(drivers),
+  devices: copy(devices),
+  profiles: copy(profiles),
+  points: copy(points),
+  users: copy(users),
+  roles: copy(roles),
+  rolePrincipalBinds: copy(rolePrincipalBinds),
+  roleResourceBinds: copy(roleResourceBinds),
+  principals: copy(principals),
+  serviceAccounts: copy(serviceAccounts),
+  tenantMemberships: copy(tenantMemberships),
+  identityAudits: copy(identityAudits),
+  localCredentials: copy(localCredentials),
+  groups: copy(groups),
+  labels: copy(labels),
+  apis: copy(apis),
+  resources: copy(resources),
+  commands: copy(commands),
+  commandParams: copy(commandParams),
+  events: copy(events),
+  eventParams: copy(eventParams),
+  attributes: copy(attributes),
+  attributeConfigs: copy(attributeConfigs),
+  alarmRules: copy(alarmRules),
+  alarmNotifies: copy(alarmNotifies),
+  alarmMessages: copy(alarmMessages),
+  alarmChannels: copy(alarmChannels),
+  alarmChannelBinds: copy(alarmChannelBinds),
+  alarmRuleStates: copy(alarmRuleStates),
+  alarmHistories: copy(alarmHistories),
+  agenticProviders: copy(agenticProviders),
+  agenticModelConfigs: copy(agenticModelConfigs),
+  agenticSessions: copy(agenticSessions),
+  agenticMessages: copy(agenticMessages),
+  mcpClients: copy(mcpClients),
+  mcpConnections: copy(mcpConnections),
+  mcpTools: copy(mcpTools),
+  mcpAudits: copy(mcpAudits),
 };

--- a/dc3-web/src/mock/handlers/agentic.ts
+++ b/dc3-web/src/mock/handlers/agentic.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from '../dispatch';
+import {paginate} from '../query';
+import {ok, responseOf} from '../response';
+import {newId, stamp} from '../crud';
+
+/** add/update/delete for the mutable agentic config collections. */
+const cud = (url: string, key: 'agenticModelConfigs' | 'agenticProviders') => {
+  on('post', `${url}/add`, (ctx) => {
+    const row: Record<string, unknown> = {...ctx.body, id: newId(), createTime: stamp(), operateTime: stamp()};
+    ctx.db[key].push(row);
+    return responseOf(ctx.config, ok(String(row.id)));
+  });
+  on('post', `${url}/update`, (ctx) => {
+    const coll = ctx.db[key];
+    const i = coll.findIndex((r) => String(r.id) === String(ctx.body?.id));
+    if (i >= 0) coll[i] = {...coll[i], ...ctx.body, operateTime: stamp()};
+    return responseOf(ctx.config, ok(String(ctx.body?.id ?? '')));
+  });
+  on('post', `${url}/delete`, (ctx) => {
+    const coll = ctx.db[key];
+    const i = coll.findIndex((r) => String(r.id) === String(ctx.params.id));
+    if (i >= 0) coll.splice(i, 1);
+    return responseOf(ctx.config, ok(String(ctx.params.id)));
+  });
+};
+
+export function registerAgenticHandlers(): void {
+  // ── agentic: model catalog & config ──
+  on('get', 'api/v3/agentic/model/list', (ctx) => {
+    const catalog = ctx.db.agenticModelConfigs.map((m) => ({
+      model: m.model,
+      label: m.label,
+      stream: m.stream,
+      toolCall: m.toolCall,
+      vision: m.vision,
+      reasoning: m.reasoning,
+    }));
+    return responseOf(ctx.config, ok(catalog));
+  });
+  on('get', 'api/v3/agentic/model/config/list', (ctx) =>
+    responseOf(ctx.config, ok(ctx.db.agenticModelConfigs)),
+  );
+  cud('api/v3/agentic/model/config', 'agenticModelConfigs');
+
+  // ── agentic: provider config ──
+  on('get', 'api/v3/agentic/provider/list', (ctx) =>
+    responseOf(ctx.config, ok(ctx.db.agenticProviders)),
+  );
+  cud('api/v3/agentic/provider/config', 'agenticProviders');
+
+  // ── agentic: sessions & messages ──
+  on('post', 'api/v3/agentic/session/list', (ctx) =>
+    responseOf(ctx.config, ok(paginate(ctx.db.agenticSessions, ctx.body))),
+  );
+  on('post', 'api/v3/agentic/session/delete', (ctx) => {
+    const id = ctx.body?.conversationId;
+    const coll = ctx.db.agenticSessions;
+    const i = coll.findIndex((r) => String(r.conversationId) === String(id));
+    if (i >= 0) coll.splice(i, 1);
+    return responseOf(ctx.config, ok(true));
+  });
+  on('post', 'api/v3/agentic/session/update', (ctx) => {
+    const coll = ctx.db.agenticSessions;
+    const i = coll.findIndex((r) => String(r.conversationId) === String(ctx.body?.conversationId));
+    if (i >= 0) coll[i] = {...coll[i], ...ctx.body};
+    return responseOf(ctx.config, ok(true));
+  });
+  on('get', 'api/v3/agentic/message/list', (ctx) => {
+    const id = ctx.params.conversation_id;
+    const rows = ctx.db.agenticMessages.filter((m) => String(m.conversationId) === String(id));
+    return responseOf(ctx.config, ok(rows));
+  });
+
+  // ── agentic: chat & actions ──
+  on('post', 'api/v3/agentic/chat/completions', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok({
+        conversationId: ctx.body?.conversationId,
+        message: {
+          role: 'assistant',
+          content: '这是一个 mock 演示回复。在真实环境中将调用配置的 AI 模型。',
+          status: 2,
+          finishReason: 'stop',
+        },
+        createTime: stamp(),
+      }),
+    ),
+  );
+  on('get', 'api/v3/agentic/action/pending', (ctx) => responseOf(ctx.config, ok([])));
+  on('post', 'api/v3/agentic/action/confirm', (ctx) => responseOf(ctx.config, ok(true)));
+  on('post', 'api/v3/agentic/action/reject', (ctx) => responseOf(ctx.config, ok(true)));
+
+  // ── agentic: attachments ──
+  on('post', 'api/v3/agentic/attachment/upload', (ctx) =>
+    responseOf(ctx.config, ok({id: newId(), ...ctx.body, createTime: stamp()})),
+  );
+  on('get', 'api/v3/agentic/attachment/list', (ctx) => responseOf(ctx.config, ok([])));
+
+  // ── MCP: OAuth metadata & clients ──
+  on('get', 'api/v3/auth/mcp/metadata', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok({
+        issuer: 'https://demo.dc3.site',
+        authorizationEndpoint: '/oauth/authorize',
+        tokenEndpoint: '/oauth/token',
+        registrationEndpoint: '/oauth/register',
+        scopesSupported: ['mcp:tools:list', 'mcp:tools:call'],
+      }),
+    ),
+  );
+  on('post', 'api/v3/auth/mcp/client/register', (ctx) => {
+    const row: Record<string, unknown> = {id: newId(), ...ctx.body, enableFlag: 'ENABLE'};
+    ctx.db.mcpClients.push(row);
+    return responseOf(ctx.config, ok(String(row.id)));
+  });
+  on('post', 'api/v3/auth/mcp/client/list', (ctx) =>
+    responseOf(ctx.config, ok(paginate(ctx.db.mcpClients, ctx.body))),
+  );
+
+  // ── MCP: connections ──
+  on('post', 'api/v3/auth/mcp/connection/list', (ctx) =>
+    responseOf(ctx.config, ok(paginate(ctx.db.mcpConnections, ctx.body))),
+  );
+  on('post', 'api/v3/auth/mcp/connection/add', (ctx) => {
+    const row: Record<string, unknown> = {...ctx.body, id: newId()};
+    ctx.db.mcpConnections.push(row);
+    return responseOf(ctx.config, ok(String(row.id)));
+  });
+  on('post', 'api/v3/auth/mcp/connection/revoke', (ctx) => {
+    const row = ctx.db.mcpConnections.find((r) => String(r.id) === String(ctx.params.id));
+    if (row) {
+      row.revokeTime = stamp();
+      row.enableFlag = 'DISABLE';
+    }
+    return responseOf(ctx.config, ok(true));
+  });
+  on('post', 'api/v3/auth/mcp/connection/tools/replace', (ctx) => responseOf(ctx.config, ok(true)));
+  on('get', 'api/v3/auth/mcp/connection/tools/list', (ctx) =>
+    responseOf(ctx.config, ok(ctx.db.mcpTools)),
+  );
+
+  // ── MCP: tool catalog & audit ──
+  on('post', 'api/v3/auth/mcp/tool/catalog/refresh', (ctx) => responseOf(ctx.config, ok(true)));
+  on('post', 'api/v3/auth/mcp/tool/list', (ctx) =>
+    responseOf(ctx.config, ok(paginate(ctx.db.mcpTools, ctx.body))),
+  );
+  on('post', 'api/v3/auth/mcp/audit/list', (ctx) =>
+    responseOf(ctx.config, ok(paginate(ctx.db.mcpAudits, ctx.body))),
+  );
+}

--- a/dc3-web/src/mock/handlers/business.ts
+++ b/dc3-web/src/mock/handlers/business.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from '../dispatch';
+import {paginate} from '../query';
+import {ok, responseOf} from '../response';
+import {newId, registerCrud, stamp} from '../crud';
+import {db} from '../db';
+
+/** Attribute-config rows scoped to one of the four owner kinds. */
+const configScope = (
+  rows: Record<string, unknown>[],
+  deviceId: unknown,
+  owner: 'driver' | 'point' | 'command' | 'event',
+  ownerId?: unknown,
+): Record<string, unknown>[] => {
+  const has = (r: Record<string, unknown>, key: string) => {
+    const v = r[key];
+    return v !== undefined && v !== null && v !== '';
+  };
+  return rows.filter((r) => {
+    if (String(r.deviceId) !== String(deviceId)) return false;
+    if (owner === 'driver') return !has(r, 'pointId') && !has(r, 'commandId') && !has(r, 'eventId');
+    if (owner === 'point') return has(r, 'pointId') && (!ownerId || String(r.pointId) === String(ownerId));
+    if (owner === 'command') return has(r, 'commandId') && (!ownerId || String(r.commandId) === String(ownerId));
+    return has(r, 'eventId') && (!ownerId || String(r.eventId) === String(ownerId));
+  });
+};
+
+export function registerBusinessHandlers(): void {
+  // ── A1. command ──
+  registerCrud({baseUrl: 'api/v3/manager/command', collection: 'commands', search: ['commandName', 'commandCode']});
+  on('get', 'api/v3/manager/command/list_by_profile_id', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok(db.commands.filter((c) => String(c.profileId) === String(ctx.params.profile_id))),
+    ),
+  );
+
+  // ── A2. command_param ──
+  registerCrud({baseUrl: 'api/v3/manager/command_param', collection: 'commandParams', exact: ['commandId']});
+  on('get', 'api/v3/manager/command_param/list_by_command_id', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok(db.commandParams.filter((p) => String(p.commandId) === String(ctx.params.command_id))),
+    ),
+  );
+
+  // ── A3. event ──
+  registerCrud({baseUrl: 'api/v3/manager/event', collection: 'events', search: ['eventName', 'eventCode']});
+  on('get', 'api/v3/manager/event/list_by_profile_id', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok(db.events.filter((e) => String(e.profileId) === String(ctx.params.profile_id))),
+    ),
+  );
+
+  // ── A4. event_param ──
+  registerCrud({baseUrl: 'api/v3/manager/event_param', collection: 'eventParams', exact: ['eventId']});
+  on('get', 'api/v3/manager/event_param/list_by_event_id', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok(db.eventParams.filter((p) => String(p.eventId) === String(ctx.params.event_id))),
+    ),
+  );
+
+  // ── A5. attribute metadata (shared across every driver) ──
+  on('get', 'api/v3/manager/driver_attribute/list_by_driver_id', (ctx) => responseOf(ctx.config, ok(db.attributes)));
+  on('get', 'api/v3/manager/point_attribute/list_by_driver_id', (ctx) => responseOf(ctx.config, ok(db.attributes)));
+  on('get', 'api/v3/manager/command_attribute/list_by_driver_id', (ctx) => responseOf(ctx.config, ok(db.attributes)));
+  on('get', 'api/v3/manager/event_attribute/list_by_driver_id', (ctx) => responseOf(ctx.config, ok(db.attributes)));
+
+  // ── A6. attribute_config (driver/point/command/event scopes) ──
+  on('get', 'api/v3/manager/driver_attribute_config/list_by_device_id', (ctx) =>
+    responseOf(ctx.config, ok(configScope(db.attributeConfigs, ctx.params.device_id, 'driver'))),
+  );
+  on('get', 'api/v3/manager/point_attribute_config/list_by_device_id', (ctx) =>
+    responseOf(ctx.config, ok(configScope(db.attributeConfigs, ctx.params.device_id, 'point'))),
+  );
+  on('get', 'api/v3/manager/point_attribute_config/list_by_device_id_and_point_id', (ctx) =>
+    responseOf(ctx.config, ok(configScope(db.attributeConfigs, ctx.params.device_id, 'point', ctx.params.point_id))),
+  );
+  on('get', 'api/v3/manager/command_attribute_config/list_by_device_id', (ctx) =>
+    responseOf(ctx.config, ok(configScope(db.attributeConfigs, ctx.params.device_id, 'command'))),
+  );
+  on('get', 'api/v3/manager/command_attribute_config/list_by_device_id_and_command_id', (ctx) =>
+    responseOf(
+      ctx.config,
+      ok(configScope(db.attributeConfigs, ctx.params.device_id, 'command', ctx.params.command_id)),
+    ),
+  );
+  on('get', 'api/v3/manager/event_attribute_config/list_by_device_id', (ctx) =>
+    responseOf(ctx.config, ok(configScope(db.attributeConfigs, ctx.params.device_id, 'event'))),
+  );
+  on('get', 'api/v3/manager/event_attribute_config/list_by_device_id_and_event_id', (ctx) =>
+    responseOf(ctx.config, ok(configScope(db.attributeConfigs, ctx.params.device_id, 'event', ctx.params.event_id))),
+  );
+  // driver_attribute_config is the only mutable config scope in the demo.
+  on('post', 'api/v3/manager/driver_attribute_config/add', (ctx) => {
+    const row: Record<string, unknown> = {...ctx.body, id: newId()};
+    db.attributeConfigs.push(row);
+    return responseOf(ctx.config, ok(String(row.id)));
+  });
+  on('post', 'api/v3/manager/driver_attribute_config/update', (ctx) => {
+    const coll = db.attributeConfigs;
+    const i = coll.findIndex((r) => String(r.id) === String(ctx.body?.id));
+    if (i >= 0) coll[i] = {...coll[i], ...ctx.body};
+    return responseOf(ctx.config, ok(String(ctx.body?.id ?? '')));
+  });
+
+  // ── B. alarm sub-resources ──
+  registerCrud({baseUrl: 'api/v3/data/rule', collection: 'alarmRules', search: ['ruleName', 'ruleCode']});
+  registerCrud({baseUrl: 'api/v3/data/notify', collection: 'alarmNotifies', search: ['notifyName']});
+  registerCrud({baseUrl: 'api/v3/data/message', collection: 'alarmMessages', search: ['messageName']});
+  registerCrud({baseUrl: 'api/v3/data/notify/channel', collection: 'alarmChannels', search: ['channelName']});
+  registerCrud({
+    baseUrl: 'api/v3/data/notify/channel/bind',
+    collection: 'alarmChannelBinds',
+    exact: ['notifyId', 'channelId'],
+  });
+  registerCrud({baseUrl: 'api/v3/data/rule/state', collection: 'alarmRuleStates', exact: ['ruleId']});
+  registerCrud({baseUrl: 'api/v3/data/notify/history', collection: 'alarmHistories'});
+
+  // ── C. command / event history (synthesized from the seed definitions) ──
+  on('post', 'api/v3/manager/command_history/list', (ctx) => {
+    const deviceId = db.devices[0]?.id ?? '1';
+    const rows = db.commands.slice(0, 3).map((c) => ({
+      recordId: newId(),
+      deviceId,
+      commandId: c.id,
+      commandName: c.commandName,
+      commandCode: c.commandCode,
+      paramValues: {},
+      status: 'SUCCESS',
+      occurTime: stamp(),
+    }));
+    return responseOf(ctx.config, ok(paginate(rows, ctx.body)));
+  });
+  on('post', 'api/v3/manager/event_history/list', (ctx) => {
+    const deviceId = db.devices[0]?.id ?? '1';
+    const rows = db.events.slice(0, 3).map((e) => ({
+      recordId: newId(),
+      deviceId,
+      eventId: e.id,
+      eventName: e.eventName,
+      eventCode: e.eventCode,
+      paramValues: {},
+      message: e.remark,
+      occurTime: stamp(),
+    }));
+    return responseOf(ctx.config, ok(paginate(rows, ctx.body)));
+  });
+}

--- a/dc3-web/src/mock/handlers/core.ts
+++ b/dc3-web/src/mock/handlers/core.ts
@@ -18,6 +18,7 @@
 import {on} from '../dispatch';
 import {matches, paginate} from '../query';
 import {ok, responseOf} from '../response';
+import {newId, stamp} from '../crud';
 
 const enableFilter = (row: Record<string, unknown>, body: any): boolean => {
   const flag = body?.enableFlag;
@@ -109,4 +110,28 @@ export function registerCoreHandlers(): void {
   on('post', 'api/v3/data/device/status/list', (ctx) =>
     responseOf(ctx.config, ok(statusMap(ctx.db.devices))),
   );
+
+  // ── CUD for mutable entities (driver stays read-only — backend-registered) ──
+  const cud = (url: string, key: 'devices' | 'profiles' | 'points') => {
+    on('post', `${url}/add`, (ctx) => {
+      const row: Record<string, unknown> = {...ctx.body, id: newId(), createTime: stamp(), operateTime: stamp()};
+      ctx.db[key].push(row);
+      return responseOf(ctx.config, ok(String(row.id)));
+    });
+    on('post', `${url}/update`, (ctx) => {
+      const coll = ctx.db[key];
+      const i = coll.findIndex((r) => String(r.id) === String(ctx.body?.id));
+      if (i >= 0) coll[i] = {...coll[i], ...ctx.body, operateTime: stamp()};
+      return responseOf(ctx.config, ok(String(ctx.body?.id ?? '')));
+    });
+    on('post', `${url}/delete`, (ctx) => {
+      const coll = ctx.db[key];
+      const i = coll.findIndex((r) => String(r.id) === String(ctx.params.id));
+      if (i >= 0) coll.splice(i, 1);
+      return responseOf(ctx.config, ok(String(ctx.params.id)));
+    });
+  };
+  cud('api/v3/manager/device', 'devices');
+  cud('api/v3/manager/profile', 'profiles');
+  cud('api/v3/manager/point', 'points');
 }

--- a/dc3-web/src/mock/handlers/settings.ts
+++ b/dc3-web/src/mock/handlers/settings.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from '../dispatch';
+import {ok, responseOf} from '../response';
+import {registerCrud} from '../crud';
+import {db} from '../db';
+
+/** Find the first row whose `id` equals `id`, compared as strings. */
+const findById = (collection: Record<string, unknown>[], id: unknown) =>
+  collection.find((c) => String(c.id) === String(id));
+
+/** Drop undefined lookups so join results stay `Record`-typed. */
+const defined = <T>(row: T | undefined): row is T => Boolean(row);
+
+/**
+ * Nest flat rows into a parent→children tree. Roots are rows whose
+ * `parentIdField` is `0` (numeric or string); children are matched by
+ * `parentIdField === node[idField]`, recursing depth-first.
+ */
+const buildTree = (
+  rows: Record<string, unknown>[],
+  idField: string,
+  parentIdField: string,
+): Record<string, unknown>[] => {
+  const nest = (node: Record<string, unknown>): Record<string, unknown> => ({
+    ...node,
+    children: rows
+      .filter((r) => String(r[parentIdField]) === String(node[idField]))
+      .map(nest),
+  });
+  return rows.filter((r) => String(r[parentIdField]) === '0').map(nest);
+};
+
+export function registerSettingsHandlers(): void {
+  // ── user ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/user_profile',
+    collection: 'users',
+    search: ['userName', 'nickName', 'phone', 'email'],
+  });
+  on('get', 'api/v3/auth/user_profile/get_by_name', (ctx) => {
+    const row = db.users.find((u) => String(u.userName) === String(ctx.params.name));
+    return responseOf(ctx.config, ok(row ?? {}));
+  });
+
+  // ── role ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/role',
+    collection: 'roles',
+    search: ['roleName', 'roleCode'],
+  });
+  on('post', 'api/v3/auth/role/list_tree', (ctx) =>
+    responseOf(ctx.config, ok(buildTree(db.roles, 'id', 'parentRoleId'))),
+  );
+
+  // ── role ↔ principal bind ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/role_principal',
+    collection: 'rolePrincipalBinds',
+    exact: ['roleId', 'principalId', 'principalType'],
+  });
+  // list_role_by_principal: roles granted to a principal
+  on('get', 'api/v3/auth/role_principal/list_role_by_principal', (ctx) => {
+    const roles = db.rolePrincipalBinds
+      .filter((b) => String(b.principalId) === String(ctx.params.principal_id))
+      .map((b) => findById(db.roles, b.roleId))
+      .filter(defined);
+    return responseOf(ctx.config, ok(roles));
+  });
+  // list_user_by_role: USER principals bound to a role → joined to user rows
+  // (userName/nickName live on db.users, keyed by principalId)
+  on('get', 'api/v3/auth/role_principal/list_user_by_role', (ctx) => {
+    const users = db.rolePrincipalBinds
+      .filter(
+        (b) => String(b.roleId) === String(ctx.params.role_id) && String(b.principalType) === 'USER',
+      )
+      .map((b) => db.users.find((u) => String(u.principalId) === String(b.principalId)))
+      .filter(defined);
+    return responseOf(ctx.config, ok(users));
+  });
+
+  // ── role ↔ resource bind ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/role_resource',
+    collection: 'roleResourceBinds',
+    exact: ['roleId', 'resourceId'],
+  });
+  on('get', 'api/v3/auth/role_resource/list_resource_by_role', (ctx) => {
+    const resources = db.roleResourceBinds
+      .filter((b) => String(b.roleId) === String(ctx.params.role_id))
+      .map((b) => findById(db.resources, b.resourceId))
+      .filter(defined);
+    return responseOf(ctx.config, ok(resources));
+  });
+  // list_resource_by_principal: principal → rolePrincipalBinds → roles → resources (deduped)
+  on('get', 'api/v3/auth/role_resource/list_resource_by_principal', (ctx) => {
+    const roleIds = db.rolePrincipalBinds
+      .filter((b) => String(b.principalId) === String(ctx.params.principal_id))
+      .map((b) => String(b.roleId));
+    const seen = new Set<string>();
+    const resources: Record<string, unknown>[] = [];
+    for (const b of db.roleResourceBinds) {
+      if (!roleIds.includes(String(b.roleId))) continue;
+      const key = String(b.resourceId);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const resource = findById(db.resources, b.resourceId);
+      if (resource) resources.push(resource);
+    }
+    return responseOf(ctx.config, ok(resources));
+  });
+  on('get', 'api/v3/auth/role_resource/list_role_by_resource', (ctx) => {
+    const roles = db.roleResourceBinds
+      .filter((b) => String(b.resourceId) === String(ctx.params.resource_id))
+      .map((b) => findById(db.roles, b.roleId))
+      .filter(defined);
+    return responseOf(ctx.config, ok(roles));
+  });
+
+  // ── principal ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/principal',
+    collection: 'principals',
+    search: ['principalName'],
+    exact: ['principalType', 'enableFlag'],
+    enable: true,
+  });
+  on('post', 'api/v3/auth/principal/list_by_ids', (ctx) => {
+    const ids = Array.isArray(ctx.body) ? ctx.body : [];
+    const idSet = new Set(ids.map((id) => String(id)));
+    return responseOf(ctx.config, ok(db.principals.filter((p) => idSet.has(String(p.id)))));
+  });
+
+  // ── service account ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/service_account',
+    collection: 'serviceAccounts',
+    search: ['serviceAccountName'],
+    enable: true,
+  });
+
+  // ── tenant membership ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/tenant_membership',
+    collection: 'tenantMemberships',
+    exact: ['principalId', 'tenantId'],
+  });
+
+  // ── identity audit ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/identity_audit',
+    collection: 'identityAudits',
+    search: ['action', 'status'],
+  });
+
+  // ── local credential ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/local_credential',
+    collection: 'localCredentials',
+    search: ['loginName'],
+  });
+  on('post', 'api/v3/auth/local_credential/reset_password', (ctx) =>
+    responseOf(ctx.config, ok(true)),
+  );
+  on('get', 'api/v3/auth/local_credential/check', (ctx) => responseOf(ctx.config, ok(true)));
+
+  // ── group ──
+  registerCrud({
+    baseUrl: 'api/v3/manager/group',
+    collection: 'groups',
+    search: ['groupName', 'groupCode'],
+    exact: ['groupTypeFlag', 'enableFlag'],
+  });
+
+  // ── label ──
+  registerCrud({
+    baseUrl: 'api/v3/manager/label',
+    collection: 'labels',
+    search: ['labelName', 'labelCode'],
+    exact: ['entityTypeFlag', 'enableFlag'],
+  });
+
+  // ── api ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/api',
+    collection: 'apis',
+    search: ['apiName', 'apiCode'],
+    exact: ['apiGroup', 'apiTypeFlag', 'enableFlag'],
+  });
+
+  // ── resource ──
+  registerCrud({
+    baseUrl: 'api/v3/auth/resource',
+    collection: 'resources',
+    search: ['resourceName', 'resourceCode'],
+    exact: ['resourceTypeFlag', 'resourceScopeFlag', 'enableFlag'],
+  });
+  on('post', 'api/v3/auth/resource/list_tree', (ctx) =>
+    responseOf(ctx.config, ok(buildTree(db.resources, 'id', 'parentResourceId'))),
+  );
+}

--- a/dc3-web/src/mock/handlers/timeseries.ts
+++ b/dc3-web/src/mock/handlers/timeseries.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {on} from '../dispatch';
+import {paginate} from '../query';
+import {ok, responseOf} from '../response';
+import {db} from '../db';
+
+const dec = (p: Record<string, unknown>): number => Number(p.valueDecimal ?? 2);
+
+/** Deterministic pseudo-random in [0,1) from a string seed — stable across reloads. */
+const hash = (s: string | number): number => {
+  let h = 2166136261;
+  for (const c of String(s)) h = (h ^ c.charCodeAt(0)) * 16777619;
+  return (h >>> 0) / 4294967296;
+};
+
+/** Pick a base/amplitude for a realistic waveform from the point's unit/name. */
+const range = (point: Record<string, unknown>): {base: number; amp: number} => {
+  const u = String(point.unit ?? '');
+  const n = String(point.pointName ?? '');
+  if (u.includes('℃') || u.includes('°C') || n.includes('温')) return {base: 25, amp: 5};
+  if (u.includes('%RH') || n.includes('湿')) return {base: 55, amp: 10};
+  if (u.includes('kW')) return {base: 2.2, amp: 0.5};
+  if (u.includes('V') || n.includes('电压')) return {base: 220, amp: 6};
+  if (u.includes('A') || n.includes('电流')) return {base: 10, amp: 2};
+  if (u.includes('%') || n.includes('率')) return {base: 60, amp: 18};
+  if (u.includes('m³')) return {base: 120, amp: 30};
+  return {base: 50, amp: 12};
+};
+
+const valueAt = (point: Record<string, unknown>, hoursAgo: number): number => {
+  const {base, amp} = range(point);
+  const id = String(point.id);
+  const wave = Math.sin(hoursAgo / 3.5 + hash(id) * 6.283) * amp;
+  const noise = (hash(`${id}-${hoursAgo}`) - 0.5) * amp * 0.2;
+  return Number((base + wave + noise).toFixed(dec(point)));
+};
+
+const stamp = (ms: number): string => {
+  const t = new Date(ms);
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${t.getFullYear()}-${p(t.getMonth() + 1)}-${p(t.getDate())} ${p(t.getHours())}:${p(t.getMinutes())}:${p(t.getSeconds())}`;
+};
+
+/** Build the 24h hourly history (most-recent first) for one device×point pair. */
+const history = (deviceId: string, point: Record<string, unknown>): Record<string, unknown>[] => {
+  const now = Date.now();
+  return Array.from({length: 24}, (_, i) => {
+    const ts = stamp(now - i * 3_600_000);
+    const v = valueAt(point, i);
+    return {
+      id: `${deviceId}-${point.id}-${i}`,
+      deviceId,
+      pointId: point.id,
+      rawValue: String(v),
+      calValue: String(v),
+      hasLatestValue: i === 0,
+      rwFlag: point.rwFlag ?? 'READ_ONLY',
+      createTime: ts,
+      operateTime: ts,
+    };
+  });
+};
+
+/** Points belong to a device via the device's profile. */
+const pointsOf = (deviceId: string): Record<string, unknown>[] => {
+  const device = db.devices.find((d) => String(d.id) === String(deviceId));
+  if (!device) return [];
+  return db.points.filter((p) => String(p.profileId) === String(device.profileId));
+};
+
+/** Flatten history across devices (and points), optionally narrowed. */
+const allRows = (deviceId?: string, pointId?: string): Record<string, unknown>[] => {
+  const devices = deviceId ? db.devices.filter((d) => String(d.id) === String(deviceId)) : db.devices;
+  const rows: Record<string, unknown>[] = [];
+  for (const device of devices) {
+    for (const point of pointsOf(String(device.id))) {
+      if (pointId && String(point.id) !== String(pointId)) continue;
+      rows.push(...history(String(device.id), point));
+    }
+  }
+  return rows;
+};
+
+/**
+ * Realistic point-value time series so the value tables/charts render a live
+ * 24h waveform instead of an empty state. Values are deterministic per point id
+ * (stable across reloads) but anchored to the current hour so the demo feels live.
+ */
+export function registerTimeseriesHandlers(): void {
+  // Latest value per device×point (only the most recent sample).
+  on('post', 'api/v3/data/point_value/latest', (ctx) => {
+    const rows = allRows(ctx.body?.deviceId, ctx.body?.pointId).filter((r) => r.hasLatestValue);
+    return responseOf(ctx.config, ok(paginate(rows, ctx.body)));
+  });
+
+  // Paged history, optionally narrowed by device/point.
+  on('post', 'api/v3/data/point_value/list', (ctx) => {
+    const rows = allRows(ctx.body?.deviceId, ctx.body?.pointId);
+    return responseOf(ctx.config, ok(paginate(rows, ctx.body)));
+  });
+
+  // GET history by device+point (query params use snake_case ids).
+  on('get', 'api/v3/data/point_value/list_history_by_device_id_and_point_id', (ctx) => {
+    const rows = allRows(ctx.params.device_id as string, ctx.params.point_id as string);
+    return responseOf(ctx.config, ok(rows));
+  });
+
+  // Point read/write commands — read returns a fresh sample, write is no-op success.
+  on('post', 'api/v3/data/point_command/read', (ctx) => {
+    const point = db.points.find((p) => String(p.id) === String(ctx.body?.pointId));
+    return responseOf(ctx.config, ok({pointId: ctx.body?.pointId, value: String(point ? valueAt(point, 0) : 0)}));
+  });
+  on('post', 'api/v3/data/point_command/write', (ctx) => responseOf(ctx.config, ok(true)));
+}

--- a/dc3-web/src/mock/index.ts
+++ b/dc3-web/src/mock/index.ts
@@ -16,8 +16,6 @@
  */
 
 import request from '@/config/axios';
-import {AUTH_HEADERS} from '@/config/constant/common';
-import {getStorage, setStorage} from '@/utils/storageUtil';
 
 import {createMockAdapter} from './adapter';
 import {setFallback} from './dispatch';
@@ -26,6 +24,10 @@ import {registerCoreHandlers} from './handlers/core';
 import {registerDashboardHandlers} from './handlers/dashboard';
 import {registerDictionaryHandlers} from './handlers/dictionary';
 import {registerMenuHandlers} from './handlers/menu';
+import {registerAgenticHandlers} from './handlers/agentic';
+import {registerBusinessHandlers} from './handlers/business';
+import {registerSettingsHandlers} from './handlers/settings';
+import {registerTimeseriesHandlers} from './handlers/timeseries';
 import {fallbackHandler} from './handlers/fallback';
 
 let installed = false;
@@ -49,15 +51,14 @@ export function setupMock(): void {
   registerDashboardHandlers();
   registerDictionaryHandlers();
   registerMenuHandlers();
+  registerTimeseriesHandlers();
+  registerSettingsHandlers();
+  registerBusinessHandlers();
+  registerAgenticHandlers();
 
   request.defaults.adapter = createMockAdapter();
 
-  // Pre-seed auth so the first navigation lands on /home without a login click.
-  // The real login flow still works (registerAuthHandlers mocks the token
-  // endpoints), so logout → login → home is demoable too.
-  if (getStorage(AUTH_HEADERS.TENANT) == null) {
-    setStorage(AUTH_HEADERS.TENANT, 'default');
-    setStorage(AUTH_HEADERS.LOGIN, 'dc3');
-    setStorage(AUTH_HEADERS.TOKEN, {salt: 'mock-salt', token: 'mock-token'});
-  }
+  // No pre-seeded auth: the demo lands on /login so visitors experience the
+  // full sign-in flow. registerAuthHandlers mocks the token endpoints, so any
+  // tenant/name + a 6+ char password logs in and reaches /home.
 }

--- a/dc3-web/src/mock/seed/agentic.ts
+++ b/dc3-web/src/mock/seed/agentic.ts
@@ -1,0 +1,732 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {AgenticMessage, AgenticModelConfig, AgenticProvider, AgenticSession} from '@/config/types';
+import type {McpAuditRecord, McpConnectionRecord, McpToolRecord, OAuthClientRecord} from '@/config/types/auth';
+
+/** Stable timestamps so the demo does not regenerate on every load. */
+const CREATED = '2026-07-15T09:30:00';
+const UPDATED = '2026-08-01T14:20:00';
+const T1 = '2026-08-05T10:12:30';
+const T2 = '2026-08-05T10:13:05';
+const T3 = '2026-08-06T08:45:00';
+const T4 = '2026-08-06T16:30:00';
+
+// ─── Agentic providers ──────────────────────────────────────────────
+
+interface ProviderDef {
+  name: string;
+  providerType: 'OPENAI_COMPATIBLE' | 'ANTHROPIC';
+  baseUrl: string;
+  defaultFlag: 'DEFAULT' | 'NOT_DEFAULT';
+  enableFlag: 'ENABLE' | 'DISABLE';
+  remark: string;
+}
+
+const providerDefs: ProviderDef[] = [
+  {
+    name: 'OpenAI',
+    providerType: 'OPENAI_COMPATIBLE',
+    baseUrl: 'https://api.openai.com/v1',
+    defaultFlag: 'DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'OpenAI 官方 API，OpenAI 兼容协议',
+  },
+  {
+    name: 'DeepSeek',
+    providerType: 'OPENAI_COMPATIBLE',
+    baseUrl: 'https://api.deepseek.com/v1',
+    defaultFlag: 'NOT_DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'DeepSeek，OpenAI 兼容接口',
+  },
+  {
+    name: 'Anthropic Claude',
+    providerType: 'ANTHROPIC',
+    baseUrl: 'https://api.anthropic.com/v1',
+    defaultFlag: 'NOT_DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'Anthropic Claude 原生 API',
+  },
+  {
+    name: '通义千问 Qwen',
+    providerType: 'OPENAI_COMPATIBLE',
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    defaultFlag: 'NOT_DEFAULT',
+    enableFlag: 'DISABLE',
+    remark: '阿里云百炼 OpenAI 兼容模式',
+  },
+];
+
+export const agenticProviders: AgenticProvider[] = providerDefs.map((p, i) => ({
+  id: `1912345678901234${567 + i}`,
+  name: p.name,
+  providerType: p.providerType,
+  baseUrl: p.baseUrl,
+  defaultFlag: p.defaultFlag,
+  enableFlag: p.enableFlag,
+  remark: p.remark,
+  createTime: CREATED,
+  operateTime: UPDATED,
+}));
+
+// ─── Agentic model configs ──────────────────────────────────────────
+
+interface ModelConfigDef {
+  model: string;
+  label: string;
+  providerIndex: number;
+  stream: boolean;
+  toolCall: boolean;
+  vision: boolean;
+  reasoning: boolean;
+  temperature: number;
+  maxTokens: number;
+  defaultFlag: 'DEFAULT' | 'NOT_DEFAULT';
+  enableFlag: 'ENABLE' | 'DISABLE';
+  remark: string;
+}
+
+const modelConfigDefs: ModelConfigDef[] = [
+  {
+    model: 'gpt-4o',
+    label: 'GPT-4o',
+    providerIndex: 0,
+    stream: true,
+    toolCall: true,
+    vision: true,
+    reasoning: false,
+    temperature: 0.7,
+    maxTokens: 4096,
+    defaultFlag: 'DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'OpenAI 旗舰多模态模型',
+  },
+  {
+    model: 'deepseek-chat',
+    label: 'DeepSeek-V3',
+    providerIndex: 1,
+    stream: true,
+    toolCall: true,
+    vision: false,
+    reasoning: false,
+    temperature: 0.5,
+    maxTokens: 8192,
+    defaultFlag: 'NOT_DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'DeepSeek 通用对话模型',
+  },
+  {
+    model: 'deepseek-reasoner',
+    label: 'DeepSeek-R1',
+    providerIndex: 1,
+    stream: true,
+    toolCall: false,
+    vision: false,
+    reasoning: true,
+    temperature: 0.2,
+    maxTokens: 8192,
+    defaultFlag: 'NOT_DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'DeepSeek 推理模型，支持思维链',
+  },
+  {
+    model: 'claude-3-5-sonnet',
+    label: 'Claude 3.5 Sonnet',
+    providerIndex: 2,
+    stream: true,
+    toolCall: true,
+    vision: true,
+    reasoning: true,
+    temperature: 0.7,
+    maxTokens: 8192,
+    defaultFlag: 'NOT_DEFAULT',
+    enableFlag: 'ENABLE',
+    remark: 'Anthropic Claude 3.5 Sonnet',
+  },
+];
+
+export const agenticModelConfigs: AgenticModelConfig[] = modelConfigDefs.map((m, i) => ({
+  id: `1912345678901235${568 + i}`,
+  model: m.model,
+  label: m.label,
+  providerId: agenticProviders[m.providerIndex]!.id,
+  providerName: agenticProviders[m.providerIndex]!.name,
+  stream: m.stream,
+  toolCall: m.toolCall,
+  vision: m.vision,
+  reasoning: m.reasoning,
+  temperature: m.temperature,
+  maxTokens: m.maxTokens,
+  defaultFlag: m.defaultFlag,
+  enableFlag: m.enableFlag,
+  remark: m.remark,
+  createTime: CREATED,
+  operateTime: UPDATED,
+}));
+
+// ─── Agentic sessions ───────────────────────────────────────────────
+
+interface SessionDef {
+  conversationId: string;
+  title: string;
+  model: string;
+  reasoningEnabled: boolean;
+  temperature: number;
+  maxTokens: number;
+}
+
+const sessionDefs: SessionDef[] = [
+  {
+    conversationId: 'b1f2a3d4-5e60-4a7b-8c9d-0a1b2c3d4e5f',
+    title: 'Modbus 设备点位查询',
+    model: 'gpt-4o',
+    reasoningEnabled: false,
+    temperature: 0.7,
+    maxTokens: 4096,
+  },
+  {
+    conversationId: 'c2e3b4c5-6f70-4b8c-9d0e-1b2c3d4e5f6a',
+    title: '电力仪表数据分析',
+    model: 'deepseek-reasoner',
+    reasoningEnabled: true,
+    temperature: 0.2,
+    maxTokens: 8192,
+  },
+  {
+    conversationId: 'd3f4c5d6-7080-4c9d-0e1f-2c3d4e5f6a7b',
+    title: '驱动配置异常排查',
+    model: 'claude-3-5-sonnet',
+    reasoningEnabled: true,
+    temperature: 0.7,
+    maxTokens: 8192,
+  },
+  {
+    conversationId: 'e4a5d6e7-8090-4d0e-1f2a-3d4e5f6a7b8c',
+    title: 'OPC-UA 连接诊断',
+    model: 'deepseek-chat',
+    reasoningEnabled: false,
+    temperature: 0.5,
+    maxTokens: 8192,
+  },
+];
+
+export const agenticSessions: AgenticSession[] = sessionDefs.map((s, i) => ({
+  conversationId: s.conversationId,
+  title: s.title,
+  sessionExt: {
+    model: s.model,
+    reasoningEnabled: s.reasoningEnabled,
+    temperature: s.temperature,
+    maxTokens: s.maxTokens,
+  },
+  createTime: i % 2 === 0 ? T1 : T3,
+  operateTime: i % 2 === 0 ? T3 : T4,
+}));
+
+// ─── Agentic messages ───────────────────────────────────────────────
+// 3 turns in session 0, 1 user/assistant pair in session 2.
+
+interface MessageDef {
+  sessionIndex: number;
+  role: 'user' | 'assistant';
+  content: string;
+  model?: string;
+  messageIndex: number;
+  status: number;
+  streaming: boolean;
+  finishReason?: string;
+  tokens?: { input: number; output: number };
+  createTime: string;
+}
+
+const messageDefs: MessageDef[] = [
+  {
+    sessionIndex: 0,
+    role: 'user',
+    content: '帮我列出 DEV-001 设备下的所有点位，并标注读写权限。',
+    messageIndex: 0,
+    status: 2,
+    streaming: false,
+    createTime: T1,
+  },
+  {
+    sessionIndex: 0,
+    role: 'assistant',
+    content:
+      'DEV-001 共挂载 3 个点位：\n- 温度（FLOAT，READ_ONLY，℃）\n- 湿度（FLOAT，READ_ONLY，%RH）\n- 电池电量（INT，READ_ONLY，%）\n如需修改其中某个点位的单位或读写属性，请告诉我具体的位号。',
+    model: 'gpt-4o',
+    messageIndex: 1,
+    status: 2,
+    streaming: false,
+    finishReason: 'stop',
+    tokens: {input: 1180, output: 726},
+    createTime: T2,
+  },
+  {
+    sessionIndex: 0,
+    role: 'user',
+    content: '把温度点位的单位从 ℃ 改成 ℉ 可以吗？',
+    messageIndex: 2,
+    status: 2,
+    streaming: false,
+    createTime: T3,
+  },
+  {
+    sessionIndex: 2,
+    role: 'user',
+    content: 'OPC-UA 驱动最近频繁掉线，帮我排查一下原因。',
+    messageIndex: 0,
+    status: 2,
+    streaming: false,
+    createTime: T4,
+  },
+  {
+    sessionIndex: 2,
+    role: 'assistant',
+    content:
+      '从日志看掉线集中在每小时第 12 分附近，且都伴随 SecureChannel 超时。建议先检查：\n1. 服务端证书是否即将过期；\n2. 网络是否存在周期性抖动（与第 12 分的定时任务重合）；\n3. 把握手超时从 5s 调到 10s 再观察一轮。',
+    model: 'claude-3-5-sonnet',
+    messageIndex: 1,
+    status: 2,
+    streaming: false,
+    finishReason: 'stop',
+    tokens: {input: 1320, output: 580},
+    createTime: T4,
+  },
+];
+
+export const agenticMessages: AgenticMessage[] = messageDefs.map((m, i) => ({
+  id: `1912345678912345${100 + i}`,
+  conversationId: agenticSessions[m.sessionIndex]?.conversationId ?? '',
+  role: m.role,
+  content: m.content,
+  contentExt: m.tokens ? {tokens: m.tokens} : undefined,
+  model: m.model,
+  messageIndex: m.messageIndex,
+  status: m.status,
+  streaming: m.streaming,
+  finishReason: m.finishReason,
+  createTime: m.createTime,
+}));
+
+// ─── MCP OAuth clients ──────────────────────────────────────────────
+
+interface ClientDef {
+  clientId: string;
+  clientName: string;
+  clientType: 'CONFIDENTIAL' | 'PUBLIC';
+  ownerPrincipalId: string;
+  serviceAccountPrincipalId: string;
+  tenantId: string;
+  authorizationGrantTypes: string;
+  redirectUris: string;
+  scopes: string;
+  enableFlag: 'ENABLE' | 'DISABLE';
+}
+
+const clientDefs: ClientDef[] = [
+  {
+    clientId: 'dc3_8f14e45fceea167a5a36dedd4bea2540',
+    clientName: 'dc3-web',
+    clientType: 'CONFIDENTIAL',
+    ownerPrincipalId: '1',
+    serviceAccountPrincipalId: '1001',
+    tenantId: '1',
+    authorizationGrantTypes: 'authorization_code,client_credentials,refresh_token',
+    redirectUris: 'http://localhost:5173/auth/mcp/callback',
+    scopes: 'mcp:tool:list mcp:tool:call mcp:connection:manage',
+    enableFlag: 'ENABLE',
+  },
+  {
+    clientId: 'dc3_2c624232cdd221771b4ea5508d82b4c7',
+    clientName: 'dc3-agentic',
+    clientType: 'CONFIDENTIAL',
+    ownerPrincipalId: '1',
+    serviceAccountPrincipalId: '1002',
+    tenantId: '1',
+    authorizationGrantTypes: 'client_credentials',
+    redirectUris: '',
+    scopes: 'mcp:tool:list mcp:tool:call',
+    enableFlag: 'ENABLE',
+  },
+  {
+    clientId: 'dc3_3d373b1a2e6d41f29a7b9c8e5d4f3a2b',
+    clientName: 'dc3-cli',
+    clientType: 'PUBLIC',
+    ownerPrincipalId: '1',
+    serviceAccountPrincipalId: '',
+    tenantId: '1',
+    authorizationGrantTypes: 'authorization_code,refresh_token',
+    redirectUris: 'http://localhost:8765/callback',
+    scopes: 'mcp:tool:list',
+    enableFlag: 'ENABLE',
+  },
+  {
+    clientId: 'dc3_9e107d9d372bb6826bd81d3542a419d6',
+    clientName: 'external-etl',
+    clientType: 'CONFIDENTIAL',
+    ownerPrincipalId: '1',
+    serviceAccountPrincipalId: '1003',
+    tenantId: '1',
+    authorizationGrantTypes: 'client_credentials',
+    redirectUris: '',
+    scopes: 'mcp:tool:list',
+    enableFlag: 'DISABLE',
+  },
+];
+
+export const mcpClients: OAuthClientRecord[] = clientDefs.map((c, i) => ({
+  id: `190112345670001${10 + i}`,
+  clientId: c.clientId,
+  clientName: c.clientName,
+  clientType: c.clientType,
+  ownerPrincipalId: c.ownerPrincipalId,
+  serviceAccountPrincipalId: c.serviceAccountPrincipalId,
+  tenantId: c.tenantId,
+  authorizationGrantTypes: c.authorizationGrantTypes,
+  redirectUris: c.redirectUris,
+  scopes: c.scopes,
+  enableFlag: c.enableFlag,
+}));
+
+// ─── MCP connections ────────────────────────────────────────────────
+
+interface ConnectionDef {
+  connectionName: string;
+  clientIndex: number;
+  principalId: string;
+  principalType: 'USER' | 'SERVICE_ACCOUNT';
+  tenantId: string;
+  grantType: 'authorization_code' | 'client_credentials';
+  enableFlag: 'ENABLE' | 'DISABLE';
+  lastUsedTime: string;
+  revokeTime?: string;
+}
+
+const connectionDefs: ConnectionDef[] = [
+  {
+    connectionName: 'Web 控制台管理员',
+    clientIndex: 0,
+    principalId: '1',
+    principalType: 'USER',
+    tenantId: '1',
+    grantType: 'authorization_code',
+    enableFlag: 'ENABLE',
+    lastUsedTime: T4,
+  },
+  {
+    connectionName: 'Agentic 服务账户',
+    clientIndex: 1,
+    principalId: '1002',
+    principalType: 'SERVICE_ACCOUNT',
+    tenantId: '1',
+    grantType: 'client_credentials',
+    enableFlag: 'ENABLE',
+    lastUsedTime: T3,
+  },
+  {
+    connectionName: 'CLI 开发者',
+    clientIndex: 2,
+    principalId: '2',
+    principalType: 'USER',
+    tenantId: '1',
+    grantType: 'authorization_code',
+    enableFlag: 'DISABLE',
+    lastUsedTime: T2,
+    revokeTime: T2,
+  },
+  {
+    connectionName: 'ETL 集成服务账户',
+    clientIndex: 3,
+    principalId: '1003',
+    principalType: 'SERVICE_ACCOUNT',
+    tenantId: '1',
+    grantType: 'client_credentials',
+    enableFlag: 'ENABLE',
+    lastUsedTime: T1,
+  },
+];
+
+export const mcpConnections: McpConnectionRecord[] = connectionDefs.map((c, i) => ({
+  id: `190112345670001${30 + i}`,
+  connectionName: c.connectionName,
+  clientId: mcpClients[c.clientIndex]!.clientId,
+  principalId: c.principalId,
+  principalType: c.principalType,
+  tenantId: c.tenantId,
+  grantType: c.grantType,
+  enableFlag: c.enableFlag,
+  lastUsedTime: c.lastUsedTime,
+  revokeTime: c.revokeTime,
+}));
+
+// ─── MCP tool catalog ───────────────────────────────────────────────
+// All tools are generated from the manager service OpenAPI; apiCode follows
+// {@code dc3-center-manager:<METHOD>:<path>} and toolId mirrors apiCode.
+// command_send is the high-risk destructive tool that requires confirmation.
+
+interface ToolDef {
+  toolName: string;
+  toolTitle: string;
+  apiPath: string;
+  httpMethod: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  permissionCode: string;
+  riskLevel: 'LOW' | 'MEDIUM' | 'HIGH';
+  readOnlyHint: number;
+  destructiveHint: number;
+  idempotentHint: number;
+  openWorldHint: number;
+  enableFlag: 'ENABLE' | 'DISABLE';
+  remark: string;
+  schemaHash: string;
+}
+
+const MANAGER = 'dc3-center-manager';
+
+const toolDefs: ToolDef[] = [
+  {
+    toolName: 'driver_list',
+    toolTitle: 'List drivers',
+    apiPath: '/driver/list',
+    httpMethod: 'POST',
+    permissionCode: `${MANAGER}:List drivers`,
+    riskLevel: 'LOW',
+    readOnlyHint: 1,
+    destructiveHint: 0,
+    idempotentHint: 1,
+    openWorldHint: 0,
+    enableFlag: 'ENABLE',
+    remark: '查询驱动列表，只读操作',
+    schemaHash: 'a3f1c9e6b2d4870f5e1a9c3b7d8e0f2a',
+  },
+  {
+    toolName: 'device_list',
+    toolTitle: 'List devices',
+    apiPath: '/device/list',
+    httpMethod: 'POST',
+    permissionCode: `${MANAGER}:List devices`,
+    riskLevel: 'LOW',
+    readOnlyHint: 1,
+    destructiveHint: 0,
+    idempotentHint: 1,
+    openWorldHint: 0,
+    enableFlag: 'ENABLE',
+    remark: '查询设备列表，只读操作',
+    schemaHash: 'b4e2d0f7c3e5981a6f2b0d4c8e9f1a3b',
+  },
+  {
+    toolName: 'device_add',
+    toolTitle: 'Add device',
+    apiPath: '/device/add',
+    httpMethod: 'POST',
+    permissionCode: `${MANAGER}:Add device`,
+    riskLevel: 'MEDIUM',
+    readOnlyHint: 0,
+    destructiveHint: 0,
+    idempotentHint: 0,
+    openWorldHint: 0,
+    enableFlag: 'ENABLE',
+    remark: '新增设备，需写权限',
+    schemaHash: 'c5f3e108d4f6a92b7a3c1e5d9f0a2b4c',
+  },
+  {
+    toolName: 'command_send',
+    toolTitle: 'Send command to device',
+    apiPath: '/command/add',
+    httpMethod: 'POST',
+    permissionCode: `${MANAGER}:Add command`,
+    riskLevel: 'HIGH',
+    readOnlyHint: 0,
+    destructiveHint: 1,
+    idempotentHint: 0,
+    openWorldHint: 1,
+    enableFlag: 'ENABLE',
+    remark: '下发指令到设备，高危操作，需人工确认',
+    schemaHash: 'd6a4f219e5a7ba3c8b4d2f6e0a1b3c5d',
+  },
+  {
+    toolName: 'device_delete',
+    toolTitle: 'Delete device',
+    apiPath: '/device/delete',
+    httpMethod: 'POST',
+    permissionCode: `${MANAGER}:Delete device`,
+    riskLevel: 'HIGH',
+    readOnlyHint: 0,
+    destructiveHint: 1,
+    idempotentHint: 1,
+    openWorldHint: 0,
+    enableFlag: 'DISABLE',
+    remark: '删除设备，高危且不可逆，默认隐藏',
+    schemaHash: 'e7b5a320f6b8cb4d9c5e3a7f1b2c4d6e',
+  },
+];
+
+export const mcpTools: McpToolRecord[] = toolDefs.map((t, i) => ({
+  id: `190112345670001${50 + i}`,
+  toolId: `${MANAGER}:${t.httpMethod}:${t.apiPath}`,
+  toolName: t.toolName,
+  toolTitle: t.toolTitle,
+  toolCategory: MANAGER,
+  serviceName: MANAGER,
+  apiCode: `${MANAGER}:${t.httpMethod}:${t.apiPath}`,
+  permissionCode: t.permissionCode,
+  httpMethod: t.httpMethod,
+  apiPath: t.apiPath,
+  schemaHash: t.schemaHash,
+  riskLevel: t.riskLevel,
+  readOnlyHint: t.readOnlyHint,
+  destructiveHint: t.destructiveHint,
+  idempotentHint: t.idempotentHint,
+  openWorldHint: t.openWorldHint,
+  enableFlag: t.enableFlag,
+  remark: t.remark,
+}));
+
+// ─── MCP audit log ──────────────────────────────────────────────────
+// toolId in audits mirrors the catalog toolId (= apiCode). Includes a denied
+// and a pending confirmation entry for the high-risk command_send tool.
+
+interface AuditDef {
+  traceId: string;
+  principalId: string;
+  principalType: 'USER' | 'SERVICE_ACCOUNT';
+  clientIndex: number;
+  connectionIndex: number;
+  toolIndex: number;
+  confirmId?: string;
+  idempotencyKey?: string;
+  argumentDigest: string;
+  status: 'SUCCESS' | 'DENIED' | 'PENDING';
+  errorCode?: string;
+  durationMs: number;
+  clientName: string;
+  clientVersion: string;
+  remoteIp: string;
+  createTime: string;
+}
+
+const auditDefs: AuditDef[] = [
+  {
+    traceId: 'f1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c',
+    principalId: '1',
+    principalType: 'USER',
+    clientIndex: 0,
+    connectionIndex: 0,
+    toolIndex: 0,
+    argumentDigest: '9b1d4f7e2a8c5601',
+    status: 'SUCCESS',
+    durationMs: 118,
+    clientName: 'dc3-web',
+    clientVersion: '1.0.4',
+    remoteIp: '10.0.12.31',
+    createTime: T1,
+  },
+  {
+    traceId: 'a2b3c4d5-e6f7-4a8b-9c0d-1e2f3a4b5c6d',
+    principalId: '1002',
+    principalType: 'SERVICE_ACCOUNT',
+    clientIndex: 1,
+    connectionIndex: 1,
+    toolIndex: 2,
+    confirmId: '7c1e9a30-4b2d-4e8f-9a1c-3d5e7f8a9b0c',
+    idempotencyKey: '3f2a1b8c-5d6e-4f7a-8b9c-0d1e2f3a4b5c',
+    argumentDigest: '4e8a1c6f0b3d7925',
+    status: 'SUCCESS',
+    durationMs: 342,
+    clientName: 'dc3-agentic',
+    clientVersion: '2026.6.1',
+    remoteIp: '10.0.12.47',
+    createTime: T2,
+  },
+  {
+    traceId: 'b3c4d5e6-f708-4b9c-0d1e-2f3a4b5c6d7e',
+    principalId: '1002',
+    principalType: 'SERVICE_ACCOUNT',
+    clientIndex: 1,
+    connectionIndex: 1,
+    toolIndex: 3,
+    argumentDigest: '1d7b9e3a5c0f4862',
+    status: 'DENIED',
+    errorCode: 'HIGH_RISK_CONFIRMATION_REQUIRED',
+    durationMs: 46,
+    clientName: 'dc3-agentic',
+    clientVersion: '2026.6.1',
+    remoteIp: '10.0.12.47',
+    createTime: T3,
+  },
+  {
+    traceId: 'c4d5e6f7-0819-4c0d-1e2f-3a4b5c6d7e8f',
+    principalId: '1',
+    principalType: 'USER',
+    clientIndex: 0,
+    connectionIndex: 0,
+    toolIndex: 3,
+    confirmId: '8d2f0b41-5c3e-4f9a-8b2d-4e6f8a9c0d1e',
+    argumentDigest: '6a2f8d4b0e7c3519',
+    status: 'PENDING',
+    durationMs: 0,
+    clientName: 'dc3-web',
+    clientVersion: '1.0.4',
+    remoteIp: '10.0.12.31',
+    createTime: T3,
+  },
+  {
+    traceId: 'd5e6f708-191a-4d1e-2f3a-4b5c6d7e8f9a',
+    principalId: '2',
+    principalType: 'USER',
+    clientIndex: 2,
+    connectionIndex: 2,
+    toolIndex: 1,
+    argumentDigest: '0c5a3d8b6e1f9274',
+    status: 'SUCCESS',
+    durationMs: 96,
+    clientName: 'dc3-cli',
+    clientVersion: '0.4.2',
+    remoteIp: '192.168.10.8',
+    createTime: T4,
+  },
+];
+
+export const mcpAudits: McpAuditRecord[] = auditDefs.map((a, i) => {
+  const tool = mcpTools[a.toolIndex]!;
+  const client = mcpClients[a.clientIndex]!;
+  const connection = mcpConnections[a.connectionIndex]!;
+  return {
+    id: `190112345670001${70 + i}`,
+    traceId: a.traceId,
+    tenantId: '1',
+    principalId: a.principalId,
+    principalType: a.principalType,
+    clientId: client.clientId,
+    connectionId: connection.id,
+    toolId: tool.toolId,
+    toolName: tool.toolName,
+    permissionCode: tool.permissionCode,
+    riskLevel: tool.riskLevel,
+    confirmId: a.confirmId,
+    idempotencyKey: a.idempotencyKey,
+    argumentDigest: a.argumentDigest,
+    status: a.status,
+    errorCode: a.errorCode,
+    durationMs: a.durationMs,
+    clientName: a.clientName,
+    clientVersion: a.clientVersion,
+    remoteIp: a.remoteIp,
+    createTime: a.createTime,
+  };
+});

--- a/dc3-web/src/mock/seed/auth.ts
+++ b/dc3-web/src/mock/seed/auth.ts
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {
+  IdentityAuditRecord,
+  LocalCredentialRecord,
+  PrincipalRecord,
+  RolePrincipalBindRecord,
+  RoleRecord,
+  RoleResourceBindForm,
+  ServiceAccountRecord,
+  TenantMembershipRecord,
+  UserRecord,
+} from '@/config/types/auth';
+
+/** Stable timestamps so the demo does not regenerate on every load. */
+const CREATED = '2026-07-15T09:30:00';
+const UPDATED = '2026-08-01T14:20:00';
+const LAST_LOGIN = '2026-08-06T08:45:00';
+const PWD_EXPIRE = '2027-07-15T09:30:00';
+const SA_EXPIRE = '2027-08-01T00:00:00';
+
+// ─── Principals ─────────────────────────────────────────────────────
+// principalId 201 = dc3 system admin (backs user 101); 204/205 are the two
+// service-account principals that own device-data-collector / mqtt-bridge.
+
+interface PrincipalDef {
+  name: string;
+  type: string;
+  displayName: string;
+  source: string;
+  lastLogin?: string;
+}
+
+const principalDefs: PrincipalDef[] = [
+  {name: 'dc3', type: 'USER', displayName: '系统管理员', source: 'LOCAL', lastLogin: LAST_LOGIN},
+  {name: 'ops', type: 'USER', displayName: '运维工程师', source: 'LOCAL', lastLogin: LAST_LOGIN},
+  {name: 'guest', type: 'USER', displayName: '访客用户', source: 'LOCAL'},
+  {name: 'device-data-collector', type: 'SERVICE_ACCOUNT', displayName: '设备数据采集', source: 'SYSTEM', lastLogin: LAST_LOGIN},
+  {name: 'mqtt-bridge', type: 'SERVICE_ACCOUNT', displayName: 'MQTT桥接接入', source: 'SYSTEM', lastLogin: LAST_LOGIN},
+];
+
+export const principals: PrincipalRecord[] = principalDefs.map((p, i) => ({
+  id: String(201 + i),
+  principalType: p.type,
+  principalName: p.name,
+  displayName: p.displayName,
+  sourceType: p.source,
+  enableFlag: 'ENABLE',
+  lockedFlag: 'UNLOCKED',
+  lastLoginTime: p.lastLogin,
+  createTime: CREATED,
+  operateTime: UPDATED,
+}));
+
+// ─── Users ──────────────────────────────────────────────────────────
+// Each user row maps 1:1 to a USER principal above (101↔201, 102↔202, 103↔203).
+
+interface UserDef {
+  principalId: string;
+  userName: string;
+  nickName: string;
+  phone: string;
+  email: string;
+  enabled?: boolean;
+}
+
+const userDefs: UserDef[] = [
+  {principalId: '201', userName: 'dc3', nickName: '系统管理员', phone: '13800138000', email: 'admin@dc3.site'},
+  {principalId: '202', userName: 'ops', nickName: '运维工程师', phone: '13800138001', email: 'ops@dc3.site'},
+  {principalId: '203', userName: 'guest', nickName: '访客用户', phone: '13800138002', email: 'guest@dc3.site', enabled: false},
+];
+
+export const users: UserRecord[] = userDefs.map((u, i) => ({
+  id: String(101 + i),
+  principalId: u.principalId,
+  userName: u.userName,
+  nickName: u.nickName,
+  phone: u.phone,
+  email: u.email,
+  enableFlag: u.enabled === false ? 'DISABLE' : 'ENABLE',
+  createTime: CREATED,
+  operateTime: UPDATED,
+}));
+
+// ─── Roles ──────────────────────────────────────────────────────────
+// parentRoleId 0 marks a root. ROLE_OPERATOR_LEAD and ROLE_AUDITOR are
+// nested under ROLE_OPERATOR / ROLE_ADMIN to exercise the role tree.
+
+interface RoleDef {
+  parentRoleId: number;
+  roleName: string;
+  roleCode: string;
+  remark: string;
+  enabled?: boolean;
+}
+
+const roleDefs: RoleDef[] = [
+  {parentRoleId: 0, roleName: '系统管理员', roleCode: 'ROLE_ADMIN', remark: '内置超级管理员，拥有全部权限'},
+  {parentRoleId: 0, roleName: '运维人员', roleCode: 'ROLE_OPERATOR', remark: '负责设备与驱动的日常运维'},
+  {parentRoleId: 0, roleName: '只读访客', roleCode: 'ROLE_VIEWER', remark: '仅可查看监控数据'},
+  {parentRoleId: 2, roleName: '运维组长', roleCode: 'ROLE_OPERATOR_LEAD', remark: '运维组长，可管理运维人员'},
+  {parentRoleId: 1, roleName: '审计员', roleCode: 'ROLE_AUDITOR', remark: '审计员，查看审计与日志', enabled: false},
+];
+
+export const roles: RoleRecord[] = roleDefs.map((r, i) => ({
+  id: String(1 + i),
+  parentRoleId: r.parentRoleId,
+  roleName: r.roleName,
+  roleCode: r.roleCode,
+  enableFlag: r.enabled === false ? 'DISABLE' : 'ENABLE',
+  remark: r.remark,
+  createTime: CREATED,
+  operateTime: UPDATED,
+}));
+
+// ─── Role ↔ Principal binds ─────────────────────────────────────────
+// dc3 (201) ↔ ROLE_ADMIN; service-account principals (204/205) ↔ operational roles.
+
+interface RolePrincipalBindDef {
+  roleId: string;
+  principalId: string;
+  principalType: string;
+}
+
+const rolePrincipalBindDefs: RolePrincipalBindDef[] = [
+  {roleId: '1', principalId: '201', principalType: 'USER'},
+  {roleId: '2', principalId: '202', principalType: 'USER'},
+  {roleId: '3', principalId: '203', principalType: 'USER'},
+  {roleId: '2', principalId: '204', principalType: 'SERVICE_ACCOUNT'},
+  {roleId: '3', principalId: '205', principalType: 'SERVICE_ACCOUNT'},
+];
+
+export const rolePrincipalBinds: RolePrincipalBindRecord[] = rolePrincipalBindDefs.map((b, i) => ({
+  id: String(1 + i),
+  roleId: b.roleId,
+  principalId: b.principalId,
+  principalType: b.principalType,
+  createTime: CREATED,
+}));
+
+// ─── Role ↔ Resource binds ──────────────────────────────────────────
+// resourceId 5001+ aligns with the manager-seed resource namespace.
+
+interface RoleResourceBindDef {
+  roleId: string;
+  resourceId: string;
+}
+
+const roleResourceBindDefs: RoleResourceBindDef[] = [
+  {roleId: '1', resourceId: '5001'},
+  {roleId: '1', resourceId: '5002'},
+  {roleId: '2', resourceId: '5003'},
+  {roleId: '2', resourceId: '5004'},
+  {roleId: '3', resourceId: '5005'},
+];
+
+export const roleResourceBinds: (RoleResourceBindForm & {id: string; createTime: string})[] =
+  roleResourceBindDefs.map((b, i) => ({
+    id: String(1 + i),
+    roleId: b.roleId,
+    resourceId: b.resourceId,
+    createTime: CREATED,
+  }));
+
+// ─── Service accounts ───────────────────────────────────────────────
+// Both service accounts are owned by the dc3 admin (principal 201).
+
+interface ServiceAccountDef {
+  principalId: string;
+  serviceAccountName: string;
+  purpose: string;
+}
+
+const serviceAccountDefs: ServiceAccountDef[] = [
+  {principalId: '204', serviceAccountName: 'device-data-collector', purpose: '采集驱动上报位号数据'},
+  {principalId: '205', serviceAccountName: 'mqtt-bridge', purpose: 'MQTT 设备接入与协议桥接'},
+];
+
+export const serviceAccounts: ServiceAccountRecord[] = serviceAccountDefs.map((s, i) => ({
+  id: String(1 + i),
+  principalId: s.principalId,
+  serviceAccountName: s.serviceAccountName,
+  ownerPrincipalId: '201',
+  purpose: s.purpose,
+  expireTime: SA_EXPIRE,
+  enableFlag: 'ENABLE',
+  createTime: CREATED,
+  operateTime: UPDATED,
+}));
+
+// ─── Tenant memberships ─────────────────────────────────────────────
+// Every principal above belongs to the default tenant as an ACTIVE member.
+
+interface TenantMembershipDef {
+  principalId: string;
+  principalType: string;
+}
+
+const tenantMembershipDefs: TenantMembershipDef[] = [
+  {principalId: '201', principalType: 'USER'},
+  {principalId: '202', principalType: 'USER'},
+  {principalId: '203', principalType: 'USER'},
+  {principalId: '204', principalType: 'SERVICE_ACCOUNT'},
+  {principalId: '205', principalType: 'SERVICE_ACCOUNT'},
+];
+
+export const tenantMemberships: TenantMembershipRecord[] = tenantMembershipDefs.map((m, i) => ({
+  id: String(1 + i),
+  tenantId: 'default',
+  principalId: m.principalId,
+  principalType: m.principalType,
+  membershipStatus: 'ACTIVE',
+  joinedTime: CREATED,
+  createTime: CREATED,
+}));
+
+// ─── Identity audits ────────────────────────────────────────────────
+// A login lifecycle for dc3 (201), a failed guest (203) login, and an admin
+// enabling the guest principal — covers LOGIN/LOGOUT/TOKEN_REFRESH/ENABLE.
+
+interface IdentityAuditDef {
+  principalId: string;
+  principalType: string;
+  action: string;
+  resourceType: string;
+  resourceId: string;
+  resourceName: string;
+  status: string;
+  errorCode?: string;
+  createTime: string;
+}
+
+const identityAuditDefs: IdentityAuditDef[] = [
+  {
+    principalId: '201',
+    principalType: 'USER',
+    action: 'LOGIN',
+    resourceType: 'SESSION',
+    resourceId: 'session-201',
+    resourceName: 'dc3-web',
+    status: 'SUCCESS',
+    createTime: '2026-08-06T08:45:00',
+  },
+  {
+    principalId: '201',
+    principalType: 'USER',
+    action: 'TOKEN_REFRESH',
+    resourceType: 'SESSION',
+    resourceId: 'session-201',
+    resourceName: 'dc3-web',
+    status: 'SUCCESS',
+    createTime: '2026-08-06T09:10:00',
+  },
+  {
+    principalId: '203',
+    principalType: 'USER',
+    action: 'LOGIN',
+    resourceType: 'SESSION',
+    resourceId: 'session-203',
+    resourceName: 'dc3-web',
+    status: 'FAILURE',
+    errorCode: 'BAD_CREDENTIALS',
+    createTime: '2026-08-05T22:30:00',
+  },
+  {
+    principalId: '201',
+    principalType: 'USER',
+    action: 'LOGOUT',
+    resourceType: 'SESSION',
+    resourceId: 'session-201',
+    resourceName: 'dc3-web',
+    status: 'SUCCESS',
+    createTime: '2026-08-05T18:00:00',
+  },
+  {
+    principalId: '201',
+    principalType: 'USER',
+    action: 'ENABLE',
+    resourceType: 'PRINCIPAL',
+    resourceId: '203',
+    resourceName: 'guest',
+    status: 'SUCCESS',
+    createTime: '2026-07-20T11:00:00',
+  },
+];
+
+export const identityAudits: IdentityAuditRecord[] = identityAuditDefs.map((a, i) => ({
+  id: String(1 + i),
+  tenantId: 'default',
+  principalId: a.principalId,
+  principalType: a.principalType,
+  action: a.action,
+  resourceType: a.resourceType,
+  resourceId: a.resourceId,
+  resourceName: a.resourceName,
+  status: a.status,
+  errorCode: a.errorCode,
+  createTime: a.createTime,
+}));
+
+// ─── Local credentials ──────────────────────────────────────────────
+// guest (203) carries failedAttempts: 3 to mirror its failed LOGIN audit above.
+
+interface LocalCredentialDef {
+  principalId: string;
+  loginName: string;
+  failedAttempts: number;
+}
+
+const localCredentialDefs: LocalCredentialDef[] = [
+  {principalId: '201', loginName: 'dc3', failedAttempts: 0},
+  {principalId: '202', loginName: 'ops', failedAttempts: 0},
+  {principalId: '203', loginName: 'guest', failedAttempts: 3},
+];
+
+export const localCredentials: LocalCredentialRecord[] = localCredentialDefs.map((c, i) => ({
+  id: String(1 + i),
+  principalId: c.principalId,
+  loginName: c.loginName,
+  credentialType: 'PASSWORD',
+  enableFlag: 'ENABLE',
+  passwordUpdatedTime: CREATED,
+  passwordExpireTime: PWD_EXPIRE,
+  failedAttempts: c.failedAttempts,
+  createTime: CREATED,
+}));

--- a/dc3-web/src/mock/seed/data.ts
+++ b/dc3-web/src/mock/seed/data.ts
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {
+  MessageRecord,
+  NotifyChannelBindRecord,
+  NotifyChannelRecord,
+  NotifyHistoryRecord,
+  NotifyRecord,
+  RuleRecord,
+  RuleStateRecord,
+} from '@/config/types/alarm';
+
+/** Stable timestamps so the demo does not regenerate on every load. */
+const CREATED = '2026-07-15T09:30:00';
+const UPDATED = '2026-08-01T14:20:00';
+const RECENT = '2026-08-05T10:15:00';
+
+/** Wraps a payload as a versioned StructuredExt, mirroring alarmEntityConfig defaults. */
+const ext = (type: string, content: Record<string, unknown>, version = 1) => ({
+  type,
+  version,
+  content,
+});
+
+interface ChannelDef {
+  name: string;
+  code: string;
+  type: string;
+  credential: string;
+  content: Record<string, unknown>;
+}
+
+const channelDefs: ChannelDef[] = [
+  {
+    name: '飞书告警机器人',
+    code: 'feishu-alarm-bot',
+    type: 'FEISHU_BOT',
+    credential: 'feishu-bot-alarm',
+    content: {signEnabled: true, cardVersion: 'interactive-card-v1', atAllAllowed: true, testMessageEnabled: true, options: {locale: 'zh-CN'}},
+  },
+  {
+    name: '钉钉运维群机器人',
+    code: 'dingtalk-ops',
+    type: 'DINGTALK_BOT',
+    credential: 'dingtalk-ops-bot',
+    content: {signEnabled: true, cardVersion: 'markdown-v1', atAllAllowed: true, testMessageEnabled: true, options: {locale: 'zh-CN'}},
+  },
+  {
+    name: '告警邮件通道',
+    code: 'alarm-email',
+    type: 'EMAIL',
+    credential: 'smtp-alarm',
+    content: {signEnabled: false, cardVersion: '', atAllAllowed: false, testMessageEnabled: true, options: {locale: 'zh-CN', from: 'alarm@dc3.site'}},
+  },
+  {
+    name: '通用 Webhook',
+    code: 'generic-webhook',
+    type: 'WEBHOOK',
+    credential: 'webhook-pagerduty',
+    content: {signEnabled: true, cardVersion: '', atAllAllowed: false, testMessageEnabled: true, options: {method: 'POST', timeoutMs: 5000}},
+  },
+];
+
+interface NotifyDef {
+  name: string;
+  code: string;
+  autoConfirm: 'AUTO' | 'MANUAL';
+  interval: number;
+  content: Record<string, unknown>;
+}
+
+const notifyDefs: NotifyDef[] = [
+  {
+    name: '标准告警通知',
+    code: 'notify-standard',
+    autoConfirm: 'AUTO',
+    interval: 300000,
+    content: {
+      dedup: {enabled: true, key: '${tenantId}:${ruleCode}:${entityId}'},
+      rateLimit: {intervalMs: 300000, maxCount: 1},
+      repeat: {enabled: false},
+      recovery: {enabled: true, sendRecoveryMessage: true, autoConfirmOnRecovery: true},
+    },
+  },
+  {
+    name: '紧急告警通知',
+    code: 'notify-urgent',
+    autoConfirm: 'MANUAL',
+    interval: 60000,
+    content: {
+      dedup: {enabled: true, key: '${tenantId}:${ruleCode}:${entityId}'},
+      rateLimit: {intervalMs: 60000, maxCount: 3},
+      repeat: {enabled: true, intervalMs: 300000},
+      recovery: {enabled: true, sendRecoveryMessage: true, autoConfirmOnRecovery: false},
+    },
+  },
+  {
+    name: '低优先级通知',
+    code: 'notify-low',
+    autoConfirm: 'AUTO',
+    interval: 900000,
+    content: {
+      dedup: {enabled: true, key: '${tenantId}:${ruleCode}:${entityId}'},
+      rateLimit: {intervalMs: 900000, maxCount: 1},
+      repeat: {enabled: false},
+      recovery: {enabled: false, sendRecoveryMessage: false, autoConfirmOnRecovery: false},
+    },
+  },
+  {
+    name: '静默恢复通知',
+    code: 'notify-silent',
+    autoConfirm: 'AUTO',
+    interval: 1800000,
+    content: {
+      dedup: {enabled: true, key: '${tenantId}:${ruleCode}:${entityId}'},
+      rateLimit: {intervalMs: 1800000, maxCount: 1},
+      repeat: {enabled: false},
+      recovery: {enabled: true, sendRecoveryMessage: true, autoConfirmOnRecovery: true},
+    },
+  },
+];
+
+interface MessageDef {
+  name: string;
+  code: string;
+  level: 'P0' | 'P1' | 'P2' | 'P3';
+  content: Record<string, unknown>;
+}
+
+const messageDefs: MessageDef[] = [
+  {
+    name: '飞书卡片告警模板',
+    code: 'msg-feishu-card',
+    level: 'P1',
+    content: {
+      variables: ['severity', 'device', 'point', 'value', 'unit', 'threshold', 'triggerTime'],
+      templates: [
+        {
+          channelType: 'FEISHU_BOT',
+          payloadType: 'CARD',
+          template: {title: '${severity} ${device} 告警', summary: '${point} 当前 ${value}${unit}, 阈值 ${threshold}${unit}'},
+        },
+      ],
+    },
+  },
+  {
+    name: '钉钉文本告警模板',
+    code: 'msg-dingtalk-text',
+    level: 'P2',
+    content: {
+      variables: ['severity', 'device', 'point', 'value', 'unit', 'threshold', 'triggerTime'],
+      templates: [
+        {
+          channelType: 'DINGTALK_BOT',
+          payloadType: 'MARKDOWN',
+          template: {title: '${severity} ${device} 告警', text: '${point}=${value}${unit} (阈值 ${threshold}${unit}) @ ${triggerTime}'},
+        },
+      ],
+    },
+  },
+  {
+    name: '邮件告警模板',
+    code: 'msg-email',
+    level: 'P2',
+    content: {
+      variables: ['severity', 'device', 'point', 'value', 'unit', 'threshold', 'triggerTime'],
+      templates: [
+        {
+          channelType: 'EMAIL',
+          payloadType: 'HTML',
+          template: {
+            subject: '[${severity}] ${device} ${point} 告警',
+            body: '<p>设备 ${device} 的 ${point} 当前值 ${value}${unit}, 超过阈值 ${threshold}${unit}。</p>',
+          },
+        },
+      ],
+    },
+  },
+  {
+    name: '通用 Webhook 模板',
+    code: 'msg-webhook-json',
+    level: 'P3',
+    content: {
+      variables: ['severity', 'device', 'point', 'value', 'unit', 'threshold', 'triggerTime'],
+      templates: [
+        {
+          channelType: 'WEBHOOK',
+          payloadType: 'JSON',
+          template: {
+            event: 'alarm',
+            severity: '${severity}',
+            device: '${device}',
+            point: '${point}',
+            value: '${value}',
+            threshold: '${threshold}',
+            triggeredAt: '${triggerTime}',
+          },
+        },
+      ],
+    },
+  },
+];
+
+interface BindDef {
+  notifyIdx: number;
+  channelIdx: number;
+  content: Record<string, unknown>;
+}
+
+// Each bind wires a notify policy to a channel, narrowing which levels it carries.
+const bindDefs: BindDef[] = [
+  {notifyIdx: 0, channelIdx: 0, content: {levels: ['P1', 'P2'], sendRecovery: true, rateLimitOverrideMs: 300000}},
+  {notifyIdx: 0, channelIdx: 3, content: {levels: ['P0', 'P1', 'P2'], sendRecovery: true, rateLimitOverrideMs: 60000}},
+  {notifyIdx: 1, channelIdx: 1, content: {levels: ['P0', 'P1'], sendRecovery: true, rateLimitOverrideMs: 60000}},
+  {notifyIdx: 2, channelIdx: 2, content: {levels: ['P2', 'P3'], sendRecovery: false, rateLimitOverrideMs: 900000}},
+  {notifyIdx: 3, channelIdx: 0, content: {levels: ['P3'], sendRecovery: true, rateLimitOverrideMs: 1800000}},
+];
+
+interface RuleDef {
+  name: string;
+  code: string;
+  entity: string;
+  notifyIdx: number;
+  messageIdx: number;
+  condition: Record<string, unknown>;
+  severity: 'P0' | 'P1' | 'P2' | 'P3';
+  remark: string;
+  enabled: boolean;
+}
+
+// entityId references point ids 5001+ from entities.ts; notify/message resolve by index.
+const ruleDefs: RuleDef[] = [
+  {
+    name: '高温告警',
+    code: 'rule-high-temp',
+    entity: '5001',
+    notifyIdx: 0,
+    messageIdx: 0,
+    condition: {field: 'numValue', operator: '>', threshold: 80, unit: '℃'},
+    severity: 'P1',
+    remark: '温度超过 80℃ 触发',
+    enabled: true,
+  },
+  {
+    name: '湿度越限告警',
+    code: 'rule-humidity',
+    entity: '5002',
+    notifyIdx: 2,
+    messageIdx: 2,
+    condition: {field: 'numValue', operator: '>', threshold: 90, unit: '%RH'},
+    severity: 'P2',
+    remark: '湿度高于 90%RH',
+    enabled: true,
+  },
+  {
+    name: '电压异常告警',
+    code: 'rule-voltage',
+    entity: '5011',
+    notifyIdx: 1,
+    messageIdx: 1,
+    condition: {field: 'numValue', operator: '>', threshold: 240, unit: 'V'},
+    severity: 'P0',
+    remark: '电压超过 240V 视为紧急',
+    enabled: true,
+  },
+  {
+    name: '网关 CPU 过载',
+    code: 'rule-cpu-overload',
+    entity: '5031',
+    notifyIdx: 0,
+    messageIdx: 3,
+    condition: {field: 'numValue', operator: '>', threshold: 85, unit: '%'},
+    severity: 'P2',
+    remark: '边缘网关 CPU 持续偏高',
+    enabled: true,
+  },
+  {
+    name: '空调回风温度高',
+    code: 'rule-hvac-return-temp',
+    entity: '5052',
+    notifyIdx: 3,
+    messageIdx: 0,
+    condition: {field: 'numValue', operator: '>', threshold: 26, unit: '℃'},
+    severity: 'P3',
+    remark: '回风温度偏高, 仅静默通知',
+    enabled: false,
+  },
+];
+
+interface StateDef {
+  ruleIdx: number;
+  entity: string;
+  state: 'FIRING' | 'PENDING' | 'RECOVERED';
+  fingerprint: string;
+  triggerCount: number;
+  first: string;
+  last: string;
+  recover: string;
+  notify: string;
+  alarmId: string;
+  content: Record<string, unknown>;
+}
+
+const stateDefs: StateDef[] = [
+  {
+    ruleIdx: 0,
+    entity: '5001',
+    state: 'FIRING',
+    fingerprint: 'fp-9f2a3c7e1b8d4f60',
+    triggerCount: 3,
+    first: '2026-08-05T08:00:00',
+    last: RECENT,
+    recover: '',
+    notify: '2026-08-05T10:16:00',
+    alarmId: 'ALM-20260805-001',
+    content: {evaluatedValue: 83.5, sampleCount: 3, lastEvalTime: RECENT},
+  },
+  {
+    ruleIdx: 1,
+    entity: '5002',
+    state: 'RECOVERED',
+    fingerprint: 'fp-4c1d8a6f2e0b9c73',
+    triggerCount: 1,
+    first: '2026-08-04T22:10:00',
+    last: '2026-08-04T22:10:00',
+    recover: '2026-08-05T06:30:00',
+    notify: '2026-08-04T22:11:00',
+    alarmId: 'ALM-20260804-014',
+    content: {evaluatedValue: 78.4, sampleCount: 1, lastEvalTime: '2026-08-05T06:30:00'},
+  },
+  {
+    ruleIdx: 2,
+    entity: '5011',
+    state: 'PENDING',
+    fingerprint: 'fp-0a7b3e5d9c218f64',
+    triggerCount: 0,
+    first: '',
+    last: '',
+    recover: '',
+    notify: '',
+    alarmId: '',
+    content: {evaluatedValue: 0, sampleCount: 0, lastEvalTime: ''},
+  },
+  {
+    ruleIdx: 3,
+    entity: '5031',
+    state: 'FIRING',
+    fingerprint: 'fp-b58e2d7104a96f3c',
+    triggerCount: 5,
+    first: '2026-08-05T07:45:00',
+    last: '2026-08-05T10:14:00',
+    recover: '',
+    notify: '2026-08-05T10:15:00',
+    alarmId: 'ALM-20260805-002',
+    content: {evaluatedValue: 92.1, sampleCount: 5, lastEvalTime: '2026-08-05T10:14:00'},
+  },
+  {
+    ruleIdx: 4,
+    entity: '5052',
+    state: 'RECOVERED',
+    fingerprint: 'fp-d31f6a90c8e45b27',
+    triggerCount: 2,
+    first: '2026-08-03T14:00:00',
+    last: '2026-08-03T18:20:00',
+    recover: '2026-08-03T20:05:00',
+    notify: '2026-08-03T18:21:00',
+    alarmId: 'ALM-20260803-007',
+    content: {evaluatedValue: 25.2, sampleCount: 2, lastEvalTime: '2026-08-03T20:05:00'},
+  },
+];
+
+interface HistoryDef {
+  ruleIdx: number;
+  notifyIdx: number;
+  messageIdx: number;
+  channelIdx: number;
+  alarmId: string;
+  target: string;
+  status: 'SUCCESS' | 'FAILED';
+  error: string;
+  retry: number;
+  time: string;
+  request: Record<string, unknown>;
+  response: Record<string, unknown>;
+}
+
+const historyDefs: HistoryDef[] = [
+  {
+    ruleIdx: 0,
+    notifyIdx: 0,
+    messageIdx: 0,
+    channelIdx: 0,
+    alarmId: 'ALM-20260805-001',
+    target: 'https://open.feishu.cn/open-apis/bot/v2/hook/****',
+    status: 'SUCCESS',
+    error: '',
+    retry: 0,
+    time: '2026-08-05T10:16:00',
+    request: {channelType: 'FEISHU_BOT', target: 'https://open.feishu.cn/open-apis/bot/v2/hook/****', payloadType: 'CARD'},
+    response: {httpStatus: 200, code: 0, bizMessage: 'ok', remoteMessageId: 'msg-feishu-90213'},
+  },
+  {
+    ruleIdx: 3,
+    notifyIdx: 0,
+    messageIdx: 3,
+    channelIdx: 3,
+    alarmId: 'ALM-20260805-002',
+    target: 'https://hooks.pagerduty.com/****',
+    status: 'SUCCESS',
+    error: '',
+    retry: 0,
+    time: '2026-08-05T10:15:30',
+    request: {channelType: 'WEBHOOK', target: 'https://hooks.pagerduty.com/****', payloadType: 'JSON'},
+    response: {httpStatus: 202, code: 0, bizMessage: 'accepted', remoteMessageId: 'pd-55aef01'},
+  },
+  {
+    ruleIdx: 2,
+    notifyIdx: 1,
+    messageIdx: 1,
+    channelIdx: 1,
+    alarmId: 'ALM-20260805-003',
+    target: 'https://oapi.dingtalk.com/robot/send?access_token=****',
+    status: 'FAILED',
+    error: 'connect timeout: dingtalk endpoint unreachable after 5000ms',
+    retry: 2,
+    time: '2026-08-05T09:30:00',
+    request: {channelType: 'DINGTALK_BOT', target: 'https://oapi.dingtalk.com/robot/send?access_token=****', payloadType: 'MARKDOWN'},
+    response: {httpStatus: 0, code: -1, bizMessage: 'connect timeout'},
+  },
+  {
+    ruleIdx: 0,
+    notifyIdx: 0,
+    messageIdx: 0,
+    channelIdx: 0,
+    alarmId: 'ALM-20260805-001',
+    target: 'https://open.feishu.cn/open-apis/bot/v2/hook/****',
+    status: 'SUCCESS',
+    error: '',
+    retry: 1,
+    time: '2026-08-05T09:10:00',
+    request: {channelType: 'FEISHU_BOT', target: 'https://open.feishu.cn/open-apis/bot/v2/hook/****', payloadType: 'CARD'},
+    response: {httpStatus: 200, code: 0, bizMessage: 'ok', remoteMessageId: 'msg-feishu-90188'},
+  },
+  {
+    ruleIdx: 1,
+    notifyIdx: 2,
+    messageIdx: 2,
+    channelIdx: 2,
+    alarmId: 'ALM-20260804-014',
+    target: 'ops@dc3.site',
+    status: 'FAILED',
+    error: 'SMTP relay rejected recipient: mailbox full',
+    retry: 3,
+    time: '2026-08-04T22:11:00',
+    request: {channelType: 'EMAIL', target: 'ops@dc3.site', payloadType: 'HTML'},
+    response: {delivered: false, smtpResponse: '550 5.2.2 Mailbox full'},
+  },
+];
+
+export const alarmChannels: NotifyChannelRecord[] = channelDefs.map((d, i) => ({
+  id: String(5120 + i),
+  channelName: d.name,
+  channelCode: d.code,
+  channelTypeFlag: d.type,
+  credentialRef: d.credential,
+  channelExt: ext('notify-channel', d.content),
+  enableFlag: 'ENABLE',
+}));
+
+export const alarmNotifies: NotifyRecord[] = notifyDefs.map((d, i) => ({
+  id: String(3072 + i),
+  notifyName: d.name,
+  notifyCode: d.code,
+  autoConfirmFlag: d.autoConfirm,
+  notifyInterval: d.interval,
+  notifyExt: ext('alarm-notify-policy', d.content),
+  enableFlag: 'ENABLE',
+  remark: `通知策略 ${d.code}`,
+}));
+
+export const alarmMessages: MessageRecord[] = messageDefs.map((d, i) => ({
+  id: String(4096 + i),
+  messageName: d.name,
+  messageCode: d.code,
+  messageLevel: d.level,
+  messageExt: ext('alarm-message-template', d.content),
+  enableFlag: 'ENABLE',
+}));
+
+export const alarmChannelBinds: NotifyChannelBindRecord[] = bindDefs.map((d, i) => ({
+  id: String(6144 + i),
+  notifyId: alarmNotifies[d.notifyIdx]!.id,
+  channelId: alarmChannels[d.channelIdx]!.id,
+  bindExt: ext('notify-channel-bind', d.content),
+  enableFlag: i === 4 ? 'DISABLE' : 'ENABLE',
+}));
+
+export const alarmRules: RuleRecord[] = ruleDefs.map((d, i) => ({
+  id: String(1024 + i),
+  ruleName: d.name,
+  ruleCode: d.code,
+  alarmTargetTypeFlag: 'POINT',
+  entityId: d.entity,
+  notifyId: alarmNotifies[d.notifyIdx]!.id,
+  messageId: alarmMessages[d.messageIdx]!.id,
+  ruleExt: ext('alarm-rule', {
+    condition: d.condition,
+    window: {mode: 'LAST', minSamples: 1},
+    severity: d.severity,
+    eventType: 'ALARM',
+  }),
+  enableFlag: d.enabled ? 'ENABLE' : 'DISABLE',
+  remark: d.remark,
+  creatorName: 'admin',
+  createTime: CREATED,
+  operatorName: 'system',
+  operateTime: UPDATED,
+}));
+
+export const alarmRuleStates: RuleStateRecord[] = stateDefs.map((d, i) => ({
+  id: String(7168 + i),
+  ruleId: alarmRules[d.ruleIdx]!.id,
+  alarmTargetTypeFlag: 'POINT',
+  entityId: d.entity,
+  fingerprint: d.fingerprint,
+  entityStateFlag: d.state,
+  firstTriggerTime: d.first,
+  lastTriggerTime: d.last,
+  lastRecoverTime: d.recover,
+  lastNotifyTime: d.notify,
+  triggerCount: d.triggerCount,
+  alarmId: d.alarmId,
+  entityStateExt: ext('rule-state-snapshot', d.content),
+}));
+
+export const alarmHistories: NotifyHistoryRecord[] = historyDefs.map((d, i) => ({
+  id: String(8192 + i),
+  ruleId: alarmRules[d.ruleIdx]!.id,
+  notifyId: alarmNotifies[d.notifyIdx]!.id,
+  messageId: alarmMessages[d.messageIdx]!.id,
+  channelId: alarmChannels[d.channelIdx]!.id,
+  alarmId: d.alarmId,
+  channelTypeFlag: alarmChannels[d.channelIdx]!.channelTypeFlag,
+  target: d.target,
+  statusFlag: d.status,
+  requestExt: ext('notify-request', d.request),
+  responseExt: ext('notify-response', d.response),
+  errorMessage: d.error,
+  retryCount: d.retry,
+  createTime: d.time,
+}));

--- a/dc3-web/src/mock/seed/manager.ts
+++ b/dc3-web/src/mock/seed/manager.ts
@@ -1,0 +1,747 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {ApiRecord, ResourceRecord} from '@/config/types/auth';
+import type {Attribute} from '@/config/types';
+import type {CommandParamRecord, CommandRecord} from '@/config/types/command';
+import type {EventParamRecord, EventRecord} from '@/config/types/event';
+import type {GroupRecord, LabelRecord} from '@/config/types/manager';
+
+import {devices, drivers, points, profiles} from './entities';
+
+/** Stable timestamps so the demo does not regenerate on every load. */
+const CREATED = '2026-07-15T09:30:00';
+const UPDATED = '2026-08-01T14:20:00';
+
+/** Common {content:{keep:''}} envelope shared by every `*Ext` field. */
+const KEEP = {content: {keep: ''}};
+
+// ─── Group ───────────────────────────────────────────────────────────
+// Two-layer tree: a root per entity type with child folders underneath.
+// parentGroupId === 0 marks a root; child rows reference the root id.
+export const groups: GroupRecord[] = [
+  {
+    id: '1',
+    parentGroupId: 0,
+    groupTypeFlag: 'DRIVER',
+    groupName: '驱动分组',
+    groupCode: 'DRIVER-GROUP',
+    groupLevel: 1,
+    groupIndex: 1,
+    enableFlag: 'ENABLE',
+    remark: '驱动根分组',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '2',
+    parentGroupId: 1,
+    groupTypeFlag: 'DRIVER',
+    groupName: 'Modbus 驱动组',
+    groupCode: 'DRIVER-MODBUS',
+    groupLevel: 2,
+    groupIndex: 1,
+    enableFlag: 'ENABLE',
+    remark: 'Modbus 系列驱动',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '3',
+    parentGroupId: 0,
+    groupTypeFlag: 'DEVICE',
+    groupName: '设备分组',
+    groupCode: 'DEVICE-GROUP',
+    groupLevel: 1,
+    groupIndex: 2,
+    enableFlag: 'ENABLE',
+    remark: '设备根分组',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '4',
+    parentGroupId: 3,
+    groupTypeFlag: 'DEVICE',
+    groupName: '温湿度设备组',
+    groupCode: 'DEVICE-TH',
+    groupLevel: 2,
+    groupIndex: 1,
+    enableFlag: 'ENABLE',
+    remark: '温湿度传感器设备',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5',
+    parentGroupId: 3,
+    groupTypeFlag: 'DEVICE',
+    groupName: '电力设备组',
+    groupCode: 'DEVICE-POWER',
+    groupLevel: 2,
+    groupIndex: 2,
+    enableFlag: 'DISABLE',
+    remark: '电力监测仪表设备',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+];
+
+// ─── Label ───────────────────────────────────────────────────────────
+// Status colors: 在线 #67C23A / 离线 #909399 / 告警 #F56C6C.
+export const labels: LabelRecord[] = [
+  {
+    id: '1',
+    labelName: '在线',
+    labelCode: 'ONLINE',
+    labelColor: '#67C23A',
+    entityTypeFlag: 'DEVICE',
+    enableFlag: 'ENABLE',
+    remark: '设备在线状态',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '2',
+    labelName: '离线',
+    labelCode: 'OFFLINE',
+    labelColor: '#909399',
+    entityTypeFlag: 'DEVICE',
+    enableFlag: 'ENABLE',
+    remark: '设备离线状态',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '3',
+    labelName: '告警',
+    labelCode: 'ALARM',
+    labelColor: '#F56C6C',
+    entityTypeFlag: 'POINT',
+    enableFlag: 'ENABLE',
+    remark: '位号越限告警',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '4',
+    labelName: '已关注',
+    labelCode: 'STARRED',
+    labelColor: '#67C23A',
+    entityTypeFlag: 'PROFILE',
+    enableFlag: 'ENABLE',
+    remark: '关注模板',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5',
+    labelName: '维护中',
+    labelCode: 'MAINTAIN',
+    labelColor: '#909399',
+    entityTypeFlag: 'DRIVER',
+    enableFlag: 'DISABLE',
+    remark: '驱动维护状态',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+];
+
+// ─── Api ─────────────────────────────────────────────────────────────
+// Covers GET/POST/PUT/DELETE across dc3-manager / dc3-auth / dc3-data and
+// the device/driver/point/profile api groups.
+export const apis: ApiRecord[] = [
+  {
+    id: '1',
+    apiName: '驱动分页查询',
+    apiCode: 'driver_list',
+    serviceName: 'dc3-manager',
+    apiTypeFlag: 'GET',
+    apiGroup: 'driver',
+    enableFlag: 'ENABLE',
+    remark: '分页查询驱动列表',
+    apiExt: {content: {url: '/driver/list', title: '驱动列表', remark: '分页查询驱动'}},
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '2',
+    apiName: '新增设备',
+    apiCode: 'device_add',
+    serviceName: 'dc3-manager',
+    apiTypeFlag: 'POST',
+    apiGroup: 'device',
+    enableFlag: 'ENABLE',
+    remark: '新增设备',
+    apiExt: {content: {url: '/device/add', title: '新增设备', remark: '创建一台新设备'}},
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '3',
+    apiName: '更新位号',
+    apiCode: 'point_update',
+    serviceName: 'dc3-data',
+    apiTypeFlag: 'PUT',
+    apiGroup: 'point',
+    enableFlag: 'ENABLE',
+    remark: '更新位号配置',
+    apiExt: {content: {url: '/point/update', title: '更新位号', remark: '修改位号基础配置'}},
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '4',
+    apiName: '删除模板',
+    apiCode: 'profile_delete',
+    serviceName: 'dc3-manager',
+    apiTypeFlag: 'DELETE',
+    apiGroup: 'profile',
+    enableFlag: 'ENABLE',
+    remark: '删除物模型模板',
+    apiExt: {content: {url: '/profile/delete', title: '删除模板', remark: '按 id 删除模板'}},
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5',
+    apiName: '令牌校验',
+    apiCode: 'token_check',
+    serviceName: 'dc3-auth',
+    apiTypeFlag: 'POST',
+    apiGroup: 'auth',
+    enableFlag: 'ENABLE',
+    remark: '校验访问令牌',
+    apiExt: {content: {url: '/auth/token/check', title: '令牌校验', remark: '校验并解析访问令牌'}},
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+];
+
+// ─── Resource ────────────────────────────────────────────────────────
+// Root node (parentResourceId=0, entityId='0') plus one entity resource per
+// type/scope. Ids start at 5001 to align with the auth seed roleResourceBind.
+export const resources: ResourceRecord[] = [
+  {
+    id: '5001',
+    parentResourceId: 0,
+    resourceName: '根资源',
+    resourceCode: 'ROOT',
+    serviceName: 'dc3-manager',
+    resourceTypeFlag: 'MENU',
+    resourceScopeFlag: 'LIST',
+    entityId: '0',
+    resourceExt: {},
+    enableFlag: 'ENABLE',
+    remark: '资源树根节点',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5002',
+    parentResourceId: 5001,
+    resourceName: '驱动新增',
+    resourceCode: 'driver_add',
+    serviceName: 'dc3-manager',
+    resourceTypeFlag: 'DRIVER',
+    resourceScopeFlag: 'ADD',
+    entityId: drivers[0]!.id, // 1001 Modbus-TCP
+    resourceExt: {},
+    enableFlag: 'ENABLE',
+    remark: '新增驱动资源',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5003',
+    parentResourceId: 5001,
+    resourceName: '设备查询',
+    resourceCode: 'device_list',
+    serviceName: 'dc3-manager',
+    resourceTypeFlag: 'DEVICE',
+    resourceScopeFlag: 'LIST',
+    entityId: devices[0]!.id, // 3001
+    resourceExt: {},
+    enableFlag: 'ENABLE',
+    remark: '查询设备资源',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5004',
+    parentResourceId: 5001,
+    resourceName: '位号更新',
+    resourceCode: 'point_update',
+    serviceName: 'dc3-data',
+    resourceTypeFlag: 'POINT',
+    resourceScopeFlag: 'UPDATE',
+    entityId: points[0]!.id, // 5001 温度
+    resourceExt: {},
+    enableFlag: 'ENABLE',
+    remark: '更新位号资源',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '5005',
+    parentResourceId: 5001,
+    resourceName: '模板删除',
+    resourceCode: 'profile_delete',
+    serviceName: 'dc3-manager',
+    resourceTypeFlag: 'PROFILE',
+    resourceScopeFlag: 'DELETE',
+    entityId: profiles[0]!.id, // 2001 温湿度传感器
+    resourceExt: {},
+    enableFlag: 'ENABLE',
+    remark: '删除模板资源',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+];
+
+// ─── Command ─────────────────────────────────────────────────────────
+// Ids start at 9001. commandTypeFlag mirrors CommandTypeEnum
+// (CUSTOM/CONFIG/ACTION); callTypeFlag mirrors CallTypeEnum (SYNC/ASYNC).
+export const commands: CommandRecord[] = [
+  {
+    id: '9001',
+    commandName: '重启网关',
+    commandCode: 'gateway_reboot',
+    commandTypeFlag: 'ACTION',
+    callTypeFlag: 'ASYNC',
+    timeout: 30,
+    commandExt: KEEP,
+    profileId: profiles[3]!.id, // 2004 边缘网关
+    enableFlag: 'ENABLE',
+    remark: '远程重启边缘网关',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9002',
+    commandName: '启动PLC',
+    commandCode: 'plc_start',
+    commandTypeFlag: 'ACTION',
+    callTypeFlag: 'SYNC',
+    timeout: 10,
+    commandExt: KEEP,
+    profileId: profiles[4]!.id, // 2005 PLC控制器
+    enableFlag: 'ENABLE',
+    remark: '启动 PLC 运行',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9003',
+    commandName: '设定运行速度',
+    commandCode: 'plc_set_speed',
+    commandTypeFlag: 'CONFIG',
+    callTypeFlag: 'SYNC',
+    timeout: 10,
+    commandExt: KEEP,
+    profileId: profiles[4]!.id, // 2005 PLC控制器
+    enableFlag: 'ENABLE',
+    remark: '下发 PLC 运行速度',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9004',
+    commandName: '设定温度',
+    commandCode: 'hvac_set_temp',
+    commandTypeFlag: 'CONFIG',
+    callTypeFlag: 'SYNC',
+    timeout: 15,
+    commandExt: KEEP,
+    profileId: profiles[5]!.id, // 2006 中央空调
+    enableFlag: 'ENABLE',
+    remark: '下发空调设定温度',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9005',
+    commandName: '远程抄表',
+    commandCode: 'meter_read',
+    commandTypeFlag: 'CUSTOM',
+    callTypeFlag: 'ASYNC',
+    timeout: 60,
+    commandExt: KEEP,
+    profileId: profiles[2]!.id, // 2003 智能水表
+    enableFlag: 'ENABLE',
+    remark: '远程读取水表累计流量',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+];
+
+// ─── Command Param ───────────────────────────────────────────────────
+// Ids start at 9101. 1–2 params per command; paramDirectionFlag mirrors
+// ParamDirectionTypeEnum (INPUT/OUTPUT).
+export const commandParams: CommandParamRecord[] = [
+  {
+    id: '9101',
+    paramName: '延迟秒数',
+    paramCode: 'delay',
+    paramDirectionFlag: 'INPUT',
+    paramTypeFlag: 'INT',
+    requiredFlag: false,
+    defaultValue: '5',
+    paramExt: KEEP,
+    commandId: '9001',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9102',
+    paramName: '执行结果',
+    paramCode: 'result',
+    paramDirectionFlag: 'OUTPUT',
+    paramTypeFlag: 'STRING',
+    requiredFlag: false,
+    defaultValue: '',
+    paramExt: KEEP,
+    commandId: '9001',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9103',
+    paramName: '启动模式',
+    paramCode: 'mode',
+    paramDirectionFlag: 'INPUT',
+    paramTypeFlag: 'BOOLEAN',
+    requiredFlag: true,
+    defaultValue: 'true',
+    paramExt: KEEP,
+    commandId: '9002',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9104',
+    paramName: '目标速度',
+    paramCode: 'speed',
+    paramDirectionFlag: 'INPUT',
+    paramTypeFlag: 'INT',
+    requiredFlag: true,
+    defaultValue: '0',
+    paramExt: KEEP,
+    commandId: '9003',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9105',
+    paramName: '目标温度',
+    paramCode: 'temperature',
+    paramDirectionFlag: 'INPUT',
+    paramTypeFlag: 'FLOAT',
+    requiredFlag: true,
+    defaultValue: '25',
+    paramExt: KEEP,
+    commandId: '9004',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9106',
+    paramName: '累计读数',
+    paramCode: 'reading',
+    paramDirectionFlag: 'OUTPUT',
+    paramTypeFlag: 'FLOAT',
+    requiredFlag: false,
+    defaultValue: '',
+    paramExt: KEEP,
+    commandId: '9005',
+    enableFlag: 'ENABLE',
+  },
+];
+
+// ─── Event ───────────────────────────────────────────────────────────
+// Ids start at 9501. eventTypeFlag mirrors EventTypeFlagEnum subset
+// (ALERT/INFO); eventLevelFlag mirrors EventLevelEnum (LOW/MEDIUM/HIGH).
+export const events: EventRecord[] = [
+  {
+    id: '9501',
+    eventName: '温度超限告警',
+    eventCode: 'temp_over',
+    eventTypeFlag: 'ALERT',
+    eventLevelFlag: 'HIGH',
+    eventExt: KEEP,
+    profileId: profiles[0]!.id, // 2001 温湿度传感器
+    enableFlag: 'ENABLE',
+    remark: '温度超过阈值上限',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9502',
+    eventName: '电池电量低',
+    eventCode: 'battery_low',
+    eventTypeFlag: 'ALERT',
+    eventLevelFlag: 'MEDIUM',
+    eventExt: KEEP,
+    profileId: profiles[0]!.id, // 2001 温湿度传感器
+    enableFlag: 'ENABLE',
+    remark: '电池电量低于告警阈值',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9503',
+    eventName: '通信中断',
+    eventCode: 'comm_lost',
+    eventTypeFlag: 'ALERT',
+    eventLevelFlag: 'HIGH',
+    eventExt: KEEP,
+    profileId: profiles[3]!.id, // 2004 边缘网关
+    enableFlag: 'ENABLE',
+    remark: '网关通信链路中断',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9504',
+    eventName: '登录通知',
+    eventCode: 'login_info',
+    eventTypeFlag: 'INFO',
+    eventLevelFlag: 'LOW',
+    eventExt: KEEP,
+    profileId: profiles[3]!.id, // 2004 边缘网关
+    enableFlag: 'ENABLE',
+    remark: '网关登录上线通知',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+  {
+    id: '9505',
+    eventName: '过流告警',
+    eventCode: 'overcurrent',
+    eventTypeFlag: 'ALERT',
+    eventLevelFlag: 'HIGH',
+    eventExt: KEEP,
+    profileId: profiles[1]!.id, // 2002 电力监测仪表
+    enableFlag: 'ENABLE',
+    remark: '电流超过安全范围',
+    createTime: CREATED,
+    operateTime: UPDATED,
+  },
+];
+
+// ─── Event Param ─────────────────────────────────────────────────────
+// Ids start at 9601. Each event carries the value/threshold it reports.
+export const eventParams: EventParamRecord[] = [
+  {
+    id: '9601',
+    paramName: '温度值',
+    paramCode: 'temperature',
+    paramTypeFlag: 'FLOAT',
+    paramExt: KEEP,
+    eventId: '9501',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9602',
+    paramName: '阈值',
+    paramCode: 'threshold',
+    paramTypeFlag: 'FLOAT',
+    paramExt: KEEP,
+    eventId: '9501',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9603',
+    paramName: '电量',
+    paramCode: 'battery',
+    paramTypeFlag: 'INT',
+    paramExt: KEEP,
+    eventId: '9502',
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '9604',
+    paramName: '电流值',
+    paramCode: 'current',
+    paramTypeFlag: 'FLOAT',
+    paramExt: KEEP,
+    eventId: '9505',
+    enableFlag: 'ENABLE',
+  },
+];
+
+// ─── Attribute ───────────────────────────────────────────────────────
+// Ids start at 8001. Modbus-flavour driver/point attributes.
+// `name` is the technical key, `attributeName` the Chinese display name,
+// `attributeCode` the form identifier consumed by device edit.
+export const attributes: Attribute[] = [
+  {
+    id: '8001',
+    name: 'host',
+    attributeName: '主机地址',
+    attributeCode: 'host',
+    attributeTypeFlag: 'STRING',
+    defaultValue: '127.0.0.1',
+    remark: 'Modbus TCP 主机地址',
+    attributeExt: KEEP,
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '8002',
+    name: 'port',
+    attributeName: '端口号',
+    attributeCode: 'port',
+    attributeTypeFlag: 'INT',
+    defaultValue: '502',
+    remark: 'Modbus TCP 端口',
+    attributeExt: KEEP,
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '8003',
+    name: 'unitId',
+    attributeName: '从站地址',
+    attributeCode: 'unitId',
+    attributeTypeFlag: 'BYTE',
+    defaultValue: '1',
+    remark: 'Modbus 从站 ID',
+    attributeExt: KEEP,
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '8004',
+    name: 'address',
+    attributeName: '寄存器地址',
+    attributeCode: 'address',
+    attributeTypeFlag: 'INT',
+    defaultValue: '0',
+    remark: 'Modbus 寄存器起始地址',
+    attributeExt: KEEP,
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '8005',
+    name: 'enabled',
+    attributeName: '使能开关',
+    attributeCode: 'enabled',
+    attributeTypeFlag: 'BOOLEAN',
+    defaultValue: 'true',
+    remark: '采集使能',
+    attributeExt: KEEP,
+    enableFlag: 'ENABLE',
+  },
+  {
+    id: '8006',
+    name: 'factor',
+    attributeName: '系数倍率',
+    attributeCode: 'factor',
+    attributeTypeFlag: 'FLOAT',
+    defaultValue: '1',
+    remark: '原始值缩放系数',
+    attributeExt: KEEP,
+    enableFlag: 'ENABLE',
+  },
+];
+
+// ─── Attribute Config ────────────────────────────────────────────────
+// Ids start at 30001. Unifies the four `*_attribute_config` tables:
+//   - driver: deviceId only
+//   - point:  deviceId + pointId
+//   - command: deviceId + commandId
+//   - event:  deviceId + eventId
+// Device ids reference the entities seed so profile bindings stay consistent
+// (e.g. devices[10]=3013 PLC/profile 2005, devices[12]=3016 HVAC/profile 2006).
+interface AttributeConfigRecord {
+  id: string;
+  deviceId: string;
+  attributeId: string;
+  configValue: string;
+  pointId?: string;
+  commandId?: string;
+  eventId?: string;
+
+  [key: string]: unknown;
+}
+
+export const attributeConfigs: AttributeConfigRecord[] = [
+  // driver_attribute_config (设备级驱动属性)
+  {
+    id: '30001',
+    deviceId: devices[0]!.id, // 3001
+    attributeId: '8001', // host
+    configValue: '192.168.1.100',
+  },
+  {
+    id: '30002',
+    deviceId: devices[0]!.id, // 3001
+    attributeId: '8002', // port
+    configValue: '502',
+  },
+  {
+    id: '30003',
+    deviceId: devices[1]!.id, // 3002
+    attributeId: '8003', // unitId
+    configValue: '2',
+  },
+  // point_attribute_config (位号级属性)
+  {
+    id: '30004',
+    deviceId: devices[0]!.id, // 3001
+    pointId: points[0]!.id, // 5001 温度
+    attributeId: '8004', // address
+    configValue: '0',
+  },
+  {
+    id: '30005',
+    deviceId: devices[0]!.id, // 3001
+    pointId: points[0]!.id, // 5001 温度
+    attributeId: '8006', // factor
+    configValue: '0.1',
+  },
+  {
+    id: '30006',
+    deviceId: devices[0]!.id, // 3001
+    pointId: points[1]!.id, // 5002 湿度
+    attributeId: '8004', // address
+    configValue: '1',
+  },
+  // command_attribute_config (命令级属性)
+  {
+    id: '30007',
+    deviceId: devices[10]!.id, // 3013 PLC (profile 2005)
+    commandId: '9003', // plc_set_speed
+    attributeId: '8004', // address
+    configValue: '10',
+  },
+  {
+    id: '30008',
+    deviceId: devices[12]!.id, // 3016 HVAC (profile 2006)
+    commandId: '9004', // hvac_set_temp
+    attributeId: '8004', // address
+    configValue: '20',
+  },
+  // event_attribute_config (事件级属性)
+  {
+    id: '30009',
+    deviceId: devices[0]!.id, // 3001 (profile 2001)
+    eventId: '9501', // temp_over
+    attributeId: '8004', // address
+    configValue: '0',
+  },
+  {
+    id: '30010',
+    deviceId: devices[2]!.id, // 3004 (profile 2002)
+    eventId: '9505', // overcurrent
+    attributeId: '8004', // address
+    configValue: '5',
+  },
+];

--- a/dc3-web/src/mock/seed/menuTree.ts
+++ b/dc3-web/src/mock/seed/menuTree.ts
@@ -55,6 +55,7 @@ export const menuTree: MenuNode[] = [
   mk('device', {url: '/device', icon: 'Management', menuIndex: 4}),
   mk('pointValue', {url: '/point_value', icon: 'Histogram', menuIndex: 5}),
   mk('settings', {
+    icon: 'Setting',
     menuIndex: 6,
     children: [
       mk('settingsIdentity', {

--- a/dc3-web/tests/unit/mock-adapter.test.ts
+++ b/dc3-web/tests/unit/mock-adapter.test.ts
@@ -40,9 +40,9 @@ describe('mock adapter', () => {
   // envelope (not an AxiosResponse). Cast once at the boundary.
   const call = (config: AxiosRequestConfig) => request(config) as Promise<R>;
 
-  it('seeds local auth so the router guard treats the session as logged in', () => {
-    expect(localStorage.getItem('X-Auth-Tenant')).not.toBeNull();
-    expect(localStorage.getItem('X-Auth-Token')).not.toBeNull();
+  it('does not pre-seed auth so the demo lands on /login', () => {
+    expect(localStorage.getItem('X-Auth-Tenant')).toBeNull();
+    expect(localStorage.getItem('X-Auth-Token')).toBeNull();
   });
 
   it('returns the full menu tree from list_tree', async () => {
@@ -78,16 +78,27 @@ describe('mock adapter', () => {
     expect(token.data).toBe('mock-token');
   });
 
-  it('stubs unregistered config-domain lists instead of erroring', async () => {
+  it('returns the seeded role list with real data', async () => {
     const res = await call({url: 'api/v3/auth/role/list', method: 'post', data: {page: {current: 1, size: 12}}});
     expect(res.ok).toBe(true);
-    expect(res.data.records.length).toBe(3);
+    expect(res.data.records.length).toBeGreaterThanOrEqual(3);
+    expect(res.data.records.some((r: any) => r.roleCode === 'ROLE_ADMIN')).toBe(true);
   });
 
-  it('returns [] for unregistered flat-array endpoints', async () => {
+  it('returns the nested role tree from list_tree', async () => {
     const res = await call({url: 'api/v3/auth/role/list_tree', method: 'post', data: {}});
     expect(res.ok).toBe(true);
-    expect(res.data).toEqual([]);
+    expect(Array.isArray(res.data)).toBe(true);
+    expect(res.data.length).toBeGreaterThan(0);
+    expect(res.data.some((r: any) => r.roleCode === 'ROLE_ADMIN')).toBe(true);
+  });
+
+  it('falls back gracefully for truly unregistered endpoints', async () => {
+    // No handler registers this fictional endpoint — fallback must shape a
+    // safe empty page instead of surfacing an error.
+    const res = await call({url: 'api/v3/data/fictional_metric/list', method: 'post', data: {page: {current: 1, size: 12}}});
+    expect(res.ok).toBe(true);
+    expect(Array.isArray(res.data.records)).toBe(true);
   });
 
   it('returns the dashboard topology with layered nodes', async () => {


### PR DESCRIPTION
## 概述
完善 dc3-web 静态 mock demo: 全模块逼真化(CUD 持久化 + 真实数据 + 时序历史) + 登录页入口 + header 菜单图标修复

## mock 逼真化
- **通用 CRUD 注册器**(`crud.ts`)+ 可变内存 db: 一份代码为任意实体注册 list/get/add/update/delete/enable/disable, 增删改即时持久化
- **4 个结构化 seed**(auth/manager/data/agentic): 27 个模块真实业务数据替代 fallback 通用桩, 关联关系一致
- **位号值 24h 历史曲线**(`timeseries`)+ 告警/事件/命令历史
- **settings/business/agentic handler** 覆盖全部 settings 模块及特殊端点(树/关联查询)
- 核心实体 device/profile/point 补 CUD

## 登录页 + header 修复
- 去掉 `main.ts` 与 `mock/index.ts` 的 mock 预置 token, demo 从登录页开始(原直接进 home)
- `menuTree` settings 顶级菜单补 Setting 图标, `Layout` 下拉子项渲染图标(原先只有文字)

## 类型
`agentic.ts`/`common.ts` 实体接口补 `[key:string]:unknown` 索引签名(与 DriverRecord 既有约定一致)

## 验证
vue-tsc 绿 / 单测 158 通过 / build:mock 成功 / dist 无内部地址泄漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)