### PR TITLE
feat(web): AI assistant with charted chat + richer dashboard/entity data

### DIFF
--- a/dc3-web/src/components/layout/Layout.vue
+++ b/dc3-web/src/components/layout/Layout.vue
@@ -105,7 +105,7 @@
           <router-view/>
         </div>
       </div>
-      <agentic-assistant v-if="!isMock"/>
+      <agentic-assistant/>
       <el-backtop :bottom="40" :right="40" target=".body-main .el-scrollbar__wrap"/>
     </div>
   </div>
@@ -135,10 +135,8 @@ const authStore = useAuthStore();
 const menuStore = useMenuStore();
 const agenticStore = useAgenticStore();
 
-// Hide the AI assistant in the static demo: its chat streams over a raw fetch
-// (src/api/agentic.ts) that bypasses the axios mock adapter. The build-time
-// MODE literal collapses this to a constant in production.
-const isMock = import.meta.env.MODE === 'mock';
+// The AI assistant is shown in every build; in mock builds the fetch
+// interceptor (src/mock/fetch.ts) answers its chat completions.
 
 const langOptions = [
   {label: 'EN', value: 'en'},

--- a/dc3-web/src/mock/fetch.ts
+++ b/dc3-web/src/mock/fetch.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2016-present the IoT DC3 original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type {AgenticVisualizationSpec} from '@/config/types';
+
+const CHAT_URL = '/api/v3/agentic/chat/completions';
+
+const encoder = new TextEncoder();
+const sse = (obj: unknown): Uint8Array => encoder.encode(`data: ${JSON.stringify(obj)}\n\n`);
+const DONE = encoder.encode('data: [DONE]\n\n');
+
+const round = (n: number, d = 1) => Number(n.toFixed(d));
+const hourly = (i: number) => `${String(i).padStart(2, '0')}:00`;
+
+/** Realistic IoT demo charts — shared by the seed history and live mock replies. */
+export const charts = {
+  tempTrend: (): AgenticVisualizationSpec => ({
+    id: 'temp-trend',
+    type: 'line',
+    title: '3 号风机轴承温度（过去 24h）',
+    description: '告警阈值 80℃',
+    dataset: Array.from({length: 24}, (_, i) => ({
+      time: hourly(i),
+      temp: round(71 + 9 * Math.sin((i - 14) / 3.8) + (i === 14 ? 5 : 0) + (i % 4) * 0.4),
+    })),
+    encode: {x: 'time', y: 'temp'},
+    scale: {y: 'linear'},
+    meta: {unit: '℃', yLabel: '温度 (℃)'},
+  }),
+  humidity: (): AgenticVisualizationSpec => ({
+    id: 'humidity',
+    type: 'area',
+    title: '车间环境湿度（过去 24h）',
+    dataset: Array.from({length: 24}, (_, i) => ({time: hourly(i), humidity: round(48 + 12 * Math.sin(i / 4) + (i % 3))})),
+    encode: {x: 'time', y: 'humidity'},
+    scale: {y: 'linear'},
+    meta: {unit: '%RH', yLabel: '湿度 (%RH)'},
+  }),
+  powerTrend: (): AgenticVisualizationSpec => ({
+    id: 'power-trend',
+    type: 'line',
+    title: '有功功率趋势（过去 24h）',
+    dataset: Array.from({length: 24}, (_, i) => ({time: hourly(i), power: round(1.6 + 0.9 * Math.sin((i - 8) / 3) + (i > 8 && i < 18 ? 0.5 : 0), 2)})),
+    encode: {x: 'time', y: 'power'},
+    scale: {y: 'linear'},
+    meta: {unit: 'kW', yLabel: '功率 (kW)'},
+  }),
+  deviceStatus: (): AgenticVisualizationSpec => ({
+    id: 'device-status',
+    type: 'donut',
+    title: '设备在线状态分布',
+    dataset: [
+      {status: '在线', count: 12},
+      {status: '离线', count: 3},
+      {status: '告警', count: 1},
+    ],
+    encode: {y: 'count', color: 'status'},
+  }),
+  pointValues: (): AgenticVisualizationSpec => ({
+    id: 'point-values',
+    type: 'column',
+    title: '关键位号实时值',
+    dataset: [
+      {point: '温度', value: 24.5},
+      {point: '湿度', value: 58.2},
+      {point: '电压', value: 221.3},
+      {point: '电流', value: 9.8},
+      {point: '功率', value: 2.1},
+    ],
+    encode: {x: 'point', y: 'value'},
+  }),
+  energyWeek: (): AgenticVisualizationSpec => ({
+    id: 'energy-week',
+    type: 'bar',
+    title: '近 7 日能耗',
+    dataset: [
+      {day: '周一', kwh: 52.4},
+      {day: '周二', kwh: 48.1},
+      {day: '周三', kwh: 55.8},
+      {day: '周四', kwh: 61.2},
+      {day: '周五', kwh: 58.7},
+      {day: '周六', kwh: 33.5},
+      {day: '周日', kwh: 30.2},
+    ],
+    encode: {x: 'day', y: 'kwh'},
+    meta: {unit: 'kWh', yLabel: '能耗 (kWh)'},
+  }),
+  alarmSummary: (): AgenticVisualizationSpec => ({
+    id: 'alarm-summary',
+    type: 'stat',
+    title: '告警概览（近 24h）',
+    dataset: [{总告警: 17, P0紧急: 1, P1重要: 4, P2次要: 12, 已恢复: 9}],
+    encode: {},
+  }),
+  driverLoad: (): AgenticVisualizationSpec => ({
+    id: 'driver-load',
+    type: 'scatter',
+    title: '驱动负载分布（CPU vs 内存）',
+    dataset: [
+      {driver: 'Modbus-TCP', cpu: 18, mem: 42},
+      {driver: 'OPC-UA', cpu: 35, mem: 58},
+      {driver: 'MQTT', cpu: 12, mem: 31},
+      {driver: 'BACnet', cpu: 22, mem: 39},
+      {driver: 'S7 PLC', cpu: 41, mem: 64},
+      {driver: 'CANopen', cpu: 8, mem: 24},
+      {driver: 'IEC104', cpu: 28, mem: 47},
+      {driver: 'OPC-DA', cpu: 33, mem: 52},
+    ],
+    encode: {x: 'cpu', y: 'mem', color: 'driver'},
+    meta: {xLabel: 'CPU (%)', yLabel: '内存 (%)'},
+  }),
+};
+
+interface Scenario {
+  match: RegExp;
+  events: {type: string; title: string; detail?: string; phase?: string; status?: string; name?: string}[];
+  text: string;
+  charts: () => AgenticVisualizationSpec[];
+}
+
+const scenarios: Scenario[] = [
+  {
+    match: /温度|temp|发热|过热/i,
+    events: [
+      {type: 'tool', title: '查询位号历史值', name: 'point_value_list', phase: 'start', status: 'running'},
+      {type: 'reasoning', title: '识别温度异常', detail: '14:00 达到 85.4℃，超过 80℃ 阈值并持续 2 小时'},
+      {type: 'tool', title: '查询位号历史值', phase: 'result', status: 'success'},
+    ],
+    text:
+      '3 号风机轴承温度在过去 24 小时持续攀升，**14:00 达到峰值 85.4℃**，超过 80℃ 告警阈值约 2 小时。结合状态分布，当前有 1 台设备处于告警。建议检查润滑与散热，必要时降低负载。',
+    charts: () => [charts.tempTrend(), charts.deviceStatus(), charts.alarmSummary()],
+  },
+  {
+    match: /能耗|用电|电量|energy|功率/i,
+    events: [
+      {type: 'tool', title: '聚合设备能耗', name: 'point_value_stats', phase: 'start', status: 'running'},
+      {type: 'reasoning', title: '能耗趋势分析', detail: '工作日能耗显著高于周末，周四峰值 61.2 kWh'},
+      {type: 'tool', title: '聚合设备能耗', phase: 'result', status: 'success'},
+    ],
+    text:
+      '近 7 日总能耗 **340.9 kWh**，工作日均值 55.2 kWh，周末降至 31.9 kWh。周四最高（61.2 kWh）。功率曲线显示白天（8-18 时）负载明显抬升，符合生产节律。可考虑在谷电时段调度高耗能任务。',
+    charts: () => [charts.energyWeek(), charts.powerTrend()],
+  },
+  {
+    match: /驱动|driver|掉线|负载/i,
+    events: [
+      {type: 'tool', title: '查询驱动运行状态', name: 'driver_status_list', phase: 'start', status: 'running'},
+      {type: 'reasoning', title: '驱动健康评估', detail: 'S7 PLC 驱动 CPU 41%、内存 64%，负载偏高'},
+      {type: 'tool', title: '查询驱动运行状态', phase: 'result', status: 'success'},
+    ],
+    text:
+      '8 个采集驱动中，**S7 PLC** 负载最高（CPU 41% / 内存 64%），**OPC-UA** 次之。CANopen 最低。OPC-UA 近期存在周期性掉线（与定时任务重合），建议检查证书有效期与握手超时。',
+    charts: () => [charts.driverLoad(), charts.deviceStatus()],
+  },
+  {
+    match: /位号|point|点位|实时/i,
+    events: [
+      {type: 'tool', title: '查询位号实时值', name: 'point_value_latest', phase: 'start', status: 'running'},
+      {type: 'tool', title: '查询位号实时值', phase: 'result', status: 'success'},
+    ],
+    text: '当前关键位号实时值：温度 24.5℃、湿度 58.2%RH、电压 221.3V、电流 9.8A、功率 2.1kW，均在正常区间。环境湿度过去 24h 在 48-60% 波动。',
+    charts: () => [charts.pointValues(), charts.humidity()],
+  },
+];
+
+const defaultScenario: Scenario = {
+  match: /.*/,
+  events: [
+    {type: 'tool', title: '查询设备总览', name: 'dashboard_stats', phase: 'start', status: 'running'},
+    {type: 'reasoning', title: '综合态势分析', detail: '汇总设备/告警/能耗指标'},
+    {type: 'tool', title: '查询设备总览', phase: 'result', status: 'success'},
+  ],
+  text:
+    '已为你汇总当前平台态势：16 台设备中 12 在线、3 离线、1 告警；近 24h 共 17 条告警（P0×1, P1×4, P2×12），已恢复 9 条。3 号风机温度异常是当前首要风险，详细分析可参见相关会话。',
+  charts: () => [charts.deviceStatus(), charts.tempTrend(), charts.alarmSummary()],
+};
+
+const pickScenario = (prompt: string): Scenario =>
+  scenarios.find((s) => s.match.test(prompt)) ?? defaultScenario;
+
+const streamChunks = (prompt: string): unknown[] => {
+  const s = pickScenario(prompt);
+  const chunks: unknown[] = s.events.map((e) => ({object: 'agentic.event', ...e}));
+  chunks.push({choices: [{delta: {content: s.text}}]});
+  for (const c of s.charts()) chunks.push({object: 'agentic.visualization', visualization: c});
+  chunks.push({choices: [{delta: {content: '需要进一步下钻某个设备或时段，告诉我即可。'}}]});
+  chunks.push({choices: [{finish_reason: 'stop'}]});
+  return chunks;
+};
+
+const mockResponse = (prompt: string, stream: boolean): Response => {
+  const s = pickScenario(prompt);
+  if (stream) {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of streamChunks(prompt)) controller.enqueue(sse(chunk));
+        controller.enqueue(DONE);
+        controller.close();
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'},
+    });
+  }
+  return new Response(
+    JSON.stringify({
+      choices: [{message: {role: 'assistant', content: s.text, contentExt: {charts: s.charts()}}, finishReason: 'stop'}],
+    }),
+    {status: 200, headers: {'Content-Type': 'application/json'}},
+  );
+};
+
+/**
+ * The agentic assistant streams chat over a raw `fetch` (SSE), bypassing the
+ * axios mock adapter. In mock builds this installs a fetch interceptor that
+ * answers `/api/v3/agentic/chat/completions` with a scripted, chart-bearing,
+ * keyword-aware reply so the AI assistant is fully demoable without a backend.
+ */
+export function installAgenticFetchMock(): void {
+  const original = window.fetch.bind(window);
+  window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes(CHAT_URL)) {
+      let stream = true;
+      let prompt = '';
+      try {
+        const body = JSON.parse(String(init?.body ?? '{}'));
+        stream = body.stream !== false;
+        const msgs = Array.isArray(body.messages) ? body.messages : [];
+        prompt = String(msgs[msgs.length - 1]?.content ?? '');
+      } catch {
+        /* defaults */
+      }
+      return Promise.resolve(mockResponse(prompt, stream));
+    }
+    return original(input as RequestInfo, init);
+  }) as typeof window.fetch;
+}

--- a/dc3-web/src/mock/handlers/dashboard.ts
+++ b/dc3-web/src/mock/handlers/dashboard.ts
@@ -18,20 +18,29 @@
 import {on} from '../dispatch';
 import {ok, okPage, responseOf} from '../response';
 import {
+  alertAging,
   alertRows,
   alertStats,
   dailyGrowth,
+  deviceStats,
+  driverStats,
+  silentSources,
+  statsActivity,
+  statsLatency,
   statsTimeseries,
   statsToday,
+  statsTop,
+  streamLatest,
   systemHealth,
   topology,
 } from '../seed/dashboard';
 
 /**
- * Home page hard dependencies. The remaining insight-card endpoints
- * (latency, activity, stream, top, alert/trend, flapping, …) are not
- * registered here on purpose — every card wraps its call in try/catch, so the
- * generic fallback (empty object/array) keeps them blank without errors.
+ * Home page hard dependencies plus the insight-card endpoints that populate
+ * the five secondary cards (live feed, analytics tabs, SLA badge, latency,
+ * activity heatmap). The remaining event-overview-only endpoints
+ * (alert/trend, flapping, correlation, …) are not registered here — every card
+ * wraps its call in try/catch, so the generic fallback keeps them blank.
  */
 export function registerDashboardHandlers(): void {
   on('get', 'api/v3/data/dashboard/stats/today', (ctx) => responseOf(ctx.config, ok(statsToday)));
@@ -44,4 +53,25 @@ export function registerDashboardHandlers(): void {
   on('get', 'api/v3/manager/dashboard/growth', (ctx) => responseOf(ctx.config, ok(dailyGrowth)));
   on('get', 'api/v3/manager/dashboard/topology', (ctx) => responseOf(ctx.config, ok(topology)));
   on('post', 'api/v3/data/dashboard/alert/page', (ctx) => responseOf(ctx.config, okPage(alertRows)));
+
+  on('get', 'api/v3/data/dashboard/stream', (ctx) => {
+    const size = Number(ctx.params.size) || streamLatest.length;
+    return responseOf(ctx.config, ok(streamLatest.slice(0, size)));
+  });
+  on('get', 'api/v3/manager/dashboard/device/stats', (ctx) => responseOf(ctx.config, ok(deviceStats)));
+  on('get', 'api/v3/manager/dashboard/driver/stats', (ctx) => responseOf(ctx.config, ok(driverStats)));
+  on('get', 'api/v3/data/dashboard/top', (ctx) => {
+    const dim = (ctx.params.dimension as keyof typeof statsTop) || 'device';
+    const rows = statsTop[dim] ?? statsTop.device;
+    const limit = Number(ctx.params.limit) || 10;
+    return responseOf(ctx.config, ok(rows.slice(0, limit)));
+  });
+  on('get', 'api/v3/data/dashboard/alert/aging', (ctx) => responseOf(ctx.config, ok(alertAging)));
+  on('get', 'api/v3/data/dashboard/silent/sources', (ctx) =>
+    responseOf(ctx.config, ok(silentSources)),
+  );
+  on('get', 'api/v3/data/dashboard/stats/latency', (ctx) => responseOf(ctx.config, ok(statsLatency)));
+  on('get', 'api/v3/data/dashboard/stats/activity', (ctx) =>
+    responseOf(ctx.config, ok(statsActivity)),
+  );
 }

--- a/dc3-web/src/mock/index.ts
+++ b/dc3-web/src/mock/index.ts
@@ -29,6 +29,7 @@ import {registerBusinessHandlers} from './handlers/business';
 import {registerSettingsHandlers} from './handlers/settings';
 import {registerTimeseriesHandlers} from './handlers/timeseries';
 import {fallbackHandler} from './handlers/fallback';
+import {installAgenticFetchMock} from './fetch';
 
 let installed = false;
 
@@ -57,6 +58,7 @@ export function setupMock(): void {
   registerAgenticHandlers();
 
   request.defaults.adapter = createMockAdapter();
+  installAgenticFetchMock();
 
   // No pre-seeded auth: the demo lands on /login so visitors experience the
   // full sign-in flow. registerAuthHandlers mocks the token endpoints, so any

--- a/dc3-web/src/mock/seed/agentic.ts
+++ b/dc3-web/src/mock/seed/agentic.ts
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import type {AgenticMessage, AgenticModelConfig, AgenticProvider, AgenticSession} from '@/config/types';
+import type {AgenticMessage, AgenticModelConfig, AgenticProvider, AgenticSession, AgenticVisualizationSpec} from '@/config/types';
 import type {McpAuditRecord, McpConnectionRecord, McpToolRecord, OAuthClientRecord} from '@/config/types/auth';
+import {charts} from '../fetch';
 
 /** Stable timestamps so the demo does not regenerate on every load. */
 const CREATED = '2026-07-15T09:30:00';
@@ -250,11 +251,14 @@ interface MessageDef {
   status: number;
   streaming: boolean;
   finishReason?: string;
+  reasoning?: string;
   tokens?: { input: number; output: number };
+  charts?: AgenticVisualizationSpec[];
   createTime: string;
 }
 
 const messageDefs: MessageDef[] = [
+  // Session 0 — Modbus 点位查询
   {
     sessionIndex: 0,
     role: 'user',
@@ -267,29 +271,93 @@ const messageDefs: MessageDef[] = [
   {
     sessionIndex: 0,
     role: 'assistant',
-    content:
-      'DEV-001 共挂载 3 个点位：\n- 温度（FLOAT，READ_ONLY，℃）\n- 湿度（FLOAT，READ_ONLY，%RH）\n- 电池电量（INT，READ_ONLY，%）\n如需修改其中某个点位的单位或读写属性，请告诉我具体的位号。',
     model: 'gpt-4o',
     messageIndex: 1,
     status: 2,
     streaming: false,
     finishReason: 'stop',
     tokens: {input: 1180, output: 726},
+    charts: [charts.pointValues()],
     createTime: T2,
+    content:
+      'DEV-001 挂载 5 个采集点位，当前实时值如上图。温度/湿度/电压/电流为只读量，功率为派生只读量。需要调整某点位的单位或读写属性，告诉我具体位号即可。',
   },
   {
     sessionIndex: 0,
     role: 'user',
-    content: '把温度点位的单位从 ℃ 改成 ℉ 可以吗？',
+    content: '看下最近 24 小时的温度和湿度趋势。',
     messageIndex: 2,
     status: 2,
     streaming: false,
     createTime: T3,
   },
   {
+    sessionIndex: 0,
+    role: 'assistant',
+    model: 'gpt-4o',
+    messageIndex: 3,
+    status: 2,
+    streaming: false,
+    finishReason: 'stop',
+    tokens: {input: 1340, output: 612},
+    charts: [charts.tempTrend(), charts.humidity()],
+    createTime: T3,
+    content:
+      '过去 24h 温度在 71-85℃ 波动，14:00 达到峰值 85.4℃（接近 80℃ 告警阈值）；湿度稳定在 48-60%RH。整体环境正常，建议关注午后温度峰值。',
+  },
+  // Session 1 — 电力仪表数据分析
+  {
+    sessionIndex: 1,
+    role: 'user',
+    content: '统计本周能耗，并分析功率趋势。',
+    messageIndex: 0,
+    status: 2,
+    streaming: false,
+    createTime: T2,
+  },
+  {
+    sessionIndex: 1,
+    role: 'assistant',
+    model: 'deepseek-reasoner',
+    messageIndex: 1,
+    status: 2,
+    streaming: false,
+    finishReason: 'stop',
+    reasoning:
+      '聚合近 7 日 point_value 历史，按日求和得能耗；功率取 24h 均值曲线，识别生产时段（8-18 时）负载抬升。',
+    tokens: {input: 2100, output: 980},
+    charts: [charts.energyWeek(), charts.powerTrend()],
+    createTime: T2,
+    content:
+      '近 7 日总能耗 **340.9 kWh**，工作日均值 55.2 kWh，周末降至 31.9 kWh，周四最高（61.2 kWh）。功率曲线在 8-18 时明显抬升，符合生产节律。建议在谷电时段调度高耗能任务以降低用电成本。',
+  },
+  {
+    sessionIndex: 1,
+    role: 'user',
+    content: '哪个设备能耗最高？',
+    messageIndex: 2,
+    status: 2,
+    streaming: false,
+    createTime: T3,
+  },
+  {
+    sessionIndex: 1,
+    role: 'assistant',
+    model: 'deepseek-reasoner',
+    messageIndex: 3,
+    status: 2,
+    streaming: false,
+    finishReason: 'stop',
+    tokens: {input: 1820, output: 540},
+    createTime: T3,
+    content:
+      '能耗 Top3：① 3 号风机（68.4 kWh，占 20%）② 注塑机 A（54.2 kWh）③ 空压机（41.7 kWh）。3 号风机近期温度偏高，可能与持续高负载相关，建议结合温度告警一并排查。',
+  },
+  // Session 2 — 驱动配置异常排查
+  {
     sessionIndex: 2,
     role: 'user',
-    content: 'OPC-UA 驱动最近频繁掉线，帮我排查一下原因。',
+    content: 'OPC-UA 驱动频繁掉线，帮我排查，顺便看下各驱动负载。',
     messageIndex: 0,
     status: 2,
     streaming: false,
@@ -298,15 +366,40 @@ const messageDefs: MessageDef[] = [
   {
     sessionIndex: 2,
     role: 'assistant',
-    content:
-      '从日志看掉线集中在每小时第 12 分附近，且都伴随 SecureChannel 超时。建议先检查：\n1. 服务端证书是否即将过期；\n2. 网络是否存在周期性抖动（与第 12 分的定时任务重合）；\n3. 把握手超时从 5s 调到 10s 再观察一轮。',
     model: 'claude-3-5-sonnet',
     messageIndex: 1,
     status: 2,
     streaming: false,
     finishReason: 'stop',
     tokens: {input: 1320, output: 580},
+    charts: [charts.driverLoad(), charts.deviceStatus()],
     createTime: T4,
+    content:
+      '日志显示 OPC-UA 掉线集中在每小时第 12 分附近，伴随 SecureChannel 超时。各驱动负载如上：S7 PLC（CPU 41%/内存 64%）、OPC-UA（35%/58%）偏高。建议：1) 检查服务端证书有效期；2) 排查第 12 分定时任务导致的网络抖动；3) 把握手超时从 5s 调到 10s 后观察一轮。',
+  },
+  // Session 3 — 设备总览
+  {
+    sessionIndex: 3,
+    role: 'user',
+    content: '当前平台整体态势如何？',
+    messageIndex: 0,
+    status: 2,
+    streaming: false,
+    createTime: T4,
+  },
+  {
+    sessionIndex: 3,
+    role: 'assistant',
+    model: 'deepseek-chat',
+    messageIndex: 1,
+    status: 2,
+    streaming: false,
+    finishReason: 'stop',
+    tokens: {input: 1560, output: 720},
+    charts: [charts.deviceStatus(), charts.tempTrend(), charts.alarmSummary()],
+    createTime: T4,
+    content:
+      '当前态势：16 台设备中 12 在线、3 离线、1 告警（3 号风机温度异常）。近 24h 共 17 条告警（P0×1 / P1×4 / P2×12），已恢复 9 条。首要风险是 3 号风机温度，建议优先处理散热与负载。',
   },
 ];
 
@@ -315,7 +408,14 @@ export const agenticMessages: AgenticMessage[] = messageDefs.map((m, i) => ({
   conversationId: agenticSessions[m.sessionIndex]?.conversationId ?? '',
   role: m.role,
   content: m.content,
-  contentExt: m.tokens ? {tokens: m.tokens} : undefined,
+  contentExt:
+    m.tokens || m.reasoning || (m.charts && m.charts.length)
+      ? {
+          ...(m.tokens ? {tokens: m.tokens} : {}),
+          ...(m.reasoning ? {reasoningContent: m.reasoning} : {}),
+          ...(m.charts && m.charts.length ? {charts: m.charts} : {}),
+        }
+      : undefined,
   model: m.model,
   messageIndex: m.messageIndex,
   status: m.status,

--- a/dc3-web/src/mock/seed/dashboard.ts
+++ b/dc3-web/src/mock/seed/dashboard.ts
@@ -16,10 +16,13 @@
  */
 
 import type {
+  AgingBacklog,
   AlertStatsSummary,
   DailyGrowthSummary,
+  SilentSource,
   StatsTimeBucket,
   StatsTodaySummary,
+  TopDimension,
   TopologyNode,
   TopologyNodeType,
   TopologyResponse,
@@ -164,3 +167,145 @@ export const alertRows: AlertRow[] = [
     message: '电压低于安全范围',
   },
 ];
+
+// ---- Phase-2 insight-card payloads ----------------------------------
+
+/** Mirrors the Row shape declared locally in LiveDataFeed.vue. */
+interface StreamRow {
+  deviceId: string;
+  pointId: string;
+  driverId: string;
+  driverName: string;
+  deviceName: string;
+  pointName: string;
+  rawValue: string;
+  calValue: string;
+  valueType: string;
+  createTime: string;
+}
+
+const driverNameOf = (id: unknown): string =>
+  drivers.find((d) => String(d.id) === String(id))?.driverName ?? '';
+
+/** Deterministic per-unit telemetry value so the live feed looks like real
+ *  sensor readings rather than flat placeholders. */
+const streamValue = (unit: string, i: number): {valueType: string; rawValue: string} => {
+  const r = (base: number, amp: number) => (base + Math.sin(i / 1.7) * amp + (i % 5) * 0.08).toFixed(2);
+  switch (unit) {
+    case '℃':
+      return {valueType: 'FLOAT', rawValue: r(23.4, 1.3)};
+    case '%RH':
+      return {valueType: 'FLOAT', rawValue: r(56.2, 3.1)};
+    case 'V':
+      return {valueType: 'FLOAT', rawValue: r(220.3, 1.4)};
+    case 'A':
+      return {valueType: 'FLOAT', rawValue: r(12.46, 0.5)};
+    case 'kW':
+      return {valueType: 'FLOAT', rawValue: r(3.12, 0.35)};
+    case '%':
+      return {valueType: 'INT', rawValue: String(72 + ((i * 7) % 27))};
+    case 'm³/h':
+      return {valueType: 'FLOAT', rawValue: r(18.6, 2.2)};
+    case 'bar':
+      return {valueType: 'FLOAT', rawValue: r(4.05, 0.18)};
+    default:
+      return {valueType: 'DOUBLE', rawValue: r(0.95, 0.04)};
+  }
+};
+
+// Flatten every (device, point) pair sharing a profile so each feed row is a
+// coherent device/point tuple the server would plausibly emit.
+const devicePointPairs = devices.flatMap((device) =>
+  points
+    .filter((p) => String(p.profileId) === String(device.profileId))
+    .map((point) => ({device, point})),
+);
+
+const STREAM_EPOCH = Date.UTC(2026, 7, 7, 14, 30, 42);
+
+export const streamLatest: StreamRow[] = devicePointPairs.slice(0, 20).map(({device, point}, i) => {
+  const {valueType, rawValue} = streamValue(point.unit ?? '', i);
+  return {
+    deviceId: String(device.id),
+    pointId: String(point.id),
+    driverId: String(device.driverId ?? ''),
+    driverName: driverNameOf(device.driverId),
+    deviceName: device.deviceName ?? '',
+    pointName: point.pointName ?? '',
+    rawValue,
+    calValue: rawValue,
+    valueType,
+    createTime: new Date(STREAM_EPOCH - i * 37000).toISOString(),
+  };
+});
+
+const countBy = <T>(items: T[], keyOf: (item: T) => string): {key: string; count: number}[] => {
+  const map = new Map<string, number>();
+  for (const item of items) {
+    const key = keyOf(item);
+    map.set(key, (map.get(key) ?? 0) + 1);
+  }
+  return [...map.entries()].map(([key, count]) => ({key, count}));
+};
+
+export const deviceStats = {
+  byEnable: countBy(devices, (d) => (d.enableFlag === 'ENABLE' ? 'ENABLED' : 'DISABLED')),
+  byProfile: countBy(devices, (d) => String(d.profileId)),
+  byDriver: countBy(devices, (d) => String(d.driverId)),
+};
+
+// byService is keyed by driver serviceName (e.g. dc3-driver-modbus); the
+// AnalyticsTabs protocol tab strips the `dc3-driver-` prefix before drawing.
+export const driverStats = {
+  byEnable: countBy(drivers, (d) => (d.enableFlag === 'ENABLE' ? 'ENABLED' : 'DISABLED')),
+  byType: countBy(drivers, (d) => String(d.driverTypeFlag ?? 'DRIVER_CLIENT')),
+  byService: countBy(devices, (d) => {
+    const drv = drivers.find((x) => String(x.id) === String(d.driverId));
+    return drv?.serviceName ?? 'unknown';
+  }),
+};
+
+const topRows = (ids: string[], base: number, step: number, jitter: number) =>
+  ids.map((id, i) => ({entityId: id, count: Math.max(1, base - i * step + (i % 3) * jitter)}));
+
+export const statsTop: Record<TopDimension, {entityId: string; count: number}[]> = {
+  device: topRows(devices.slice(0, 10).map((d) => String(d.id)), 342, 28, 6),
+  point: topRows(points.slice(0, 10).map((p) => String(p.id)), 286, 23, 7),
+  driver: topRows(drivers.slice(0, 8).map((d) => String(d.id)), 524, 58, 4),
+};
+
+export const alertAging: AgingBacklog = {under1h: 24, h1to6: 13, h6to24: 6, over24h: 3, total: 46};
+
+const SILENT_BASE = Date.UTC(2026, 7, 7, 14, 5, 0);
+export const silentSources: SilentSource[] = [
+  {deviceId: String(devices[1]?.id ?? 3002), pointId: String(points[0]?.id ?? 5001), lastSeen: new Date(SILENT_BASE - 2_074_000).toISOString(), silentSeconds: 2074},
+  {deviceId: String(devices[3]?.id ?? 3004), pointId: String(points[3]?.id ?? 5004), lastSeen: new Date(SILENT_BASE - 1_536_000).toISOString(), silentSeconds: 1536},
+  {deviceId: String(devices[5]?.id ?? 3006), pointId: String(points[1]?.id ?? 5002), lastSeen: new Date(SILENT_BASE - 1_102_000).toISOString(), silentSeconds: 1102},
+  {deviceId: String(devices[7]?.id ?? 3008), pointId: String(points[6]?.id ?? 5007), lastSeen: new Date(SILENT_BASE - 3_640_000).toISOString(), silentSeconds: 3640},
+  {deviceId: String(devices[9]?.id ?? 3010), pointId: String(points[2]?.id ?? 5003), lastSeen: new Date(SILENT_BASE - 988_000).toISOString(), silentSeconds: 988},
+  {deviceId: String(devices[2]?.id ?? 3003), pointId: String(points[5]?.id ?? 5006), lastSeen: new Date(SILENT_BASE - 2_752_000).toISOString(), silentSeconds: 2752},
+];
+
+// 6 latency buckets: <100ms / 100-500ms / 0.5-1s / 1-5s / 5-30s / >30s.
+export const statsLatency = [
+  {bin: 0, count: 8420},
+  {bin: 1, count: 1284},
+  {bin: 2, count: 312},
+  {bin: 3, count: 87},
+  {bin: 4, count: 19},
+  {bin: 5, count: 4},
+];
+
+// 7 (Sun..Sat) x 24 (hour) activity grid — hot on weekday business hours,
+// cool overnight and on weekends, matching real IoT traffic shape.
+const activityCount = (dow: number, hour: number): number => {
+  const weekend = dow === 0 || dow === 6;
+  const peak = !weekend && hour >= 9 && hour <= 18;
+  const day = !weekend && hour >= 7 && hour <= 21;
+  const base = weekend ? 5 : peak ? 56 : day ? 24 : 3;
+  return Math.max(0, Math.round(base + Math.sin((hour + dow) / 2) * (peak ? 16 : 5)));
+};
+
+export const statsActivity = Array.from({length: 7}, (_, dow) =>
+  Array.from({length: 24}, (_, hour) => ({dow, hour, count: activityCount(dow, hour)})),
+).flat();

--- a/dc3-web/src/mock/seed/entities.ts
+++ b/dc3-web/src/mock/seed/entities.ts
@@ -40,6 +40,15 @@ const driverDefs: DriverDef[] = [
   {name: 'CANopen Driver', code: 'canopen', service: 'dc3-driver-canopen', host: '127.0.0.1:8206', enabled: false},
   {name: 'IEC104 Driver', code: 'iec104', service: 'dc3-driver-iec104', host: '127.0.0.1:8207'},
   {name: 'OPC-DA Driver', code: 'opcda', service: 'dc3-driver-opcda', host: '127.0.0.1:8208'},
+  {name: 'Modbus-RTU Driver', code: 'modbus-rtu', service: 'dc3-driver-modbus-rtu', host: '127.0.0.1:8209'},
+  {name: 'DLT645 Driver', code: 'dlt645', service: 'dc3-driver-dlt645', host: '127.0.0.1:8210'},
+  {name: 'IEC61850 Driver', code: 'iec61850', service: 'dc3-driver-iec61850', host: '127.0.0.1:8211'},
+  {name: 'BACnet/IP Driver', code: 'bacnet-ip', service: 'dc3-driver-bacnet-ip', host: '127.0.0.1:8212', enabled: false},
+  {name: 'MQTT-SN Driver', code: 'mqtt-sn', service: 'dc3-driver-mqtt-sn', host: '127.0.0.1:8213'},
+  {name: 'LoRaWAN Driver', code: 'lorawan', service: 'dc3-driver-lorawan', host: '127.0.0.1:8214'},
+  {name: 'Zigbee Driver', code: 'zigbee', service: 'dc3-driver-zigbee', host: '127.0.0.1:8215'},
+  {name: 'CoAP Driver', code: 'coap', service: 'dc3-driver-coap', host: '127.0.0.1:8216', enabled: false},
+  {name: 'HJ212 Driver', code: 'hj212', service: 'dc3-driver-hj212', host: '127.0.0.1:8217'},
 ];
 
 interface PointDef {
@@ -110,6 +119,95 @@ const profileDefs: ProfileDef[] = [
       {name: '风机转速', type: 'INT', rw: 'READ_WRITE', unit: 'rpm'},
     ],
   },
+  {
+    name: '智能电表',
+    code: 'SMART-ELECTRIC-METER',
+    points: [
+      {name: '组合有功电能', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kWh'},
+      {name: '正向有功电能', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kWh'},
+      {name: '电压', type: 'FLOAT', rw: 'READ_ONLY', unit: 'V'},
+      {name: '电流', type: 'FLOAT', rw: 'READ_ONLY', unit: 'A'},
+      {name: '频率', type: 'FLOAT', rw: 'READ_ONLY', unit: 'Hz'},
+    ],
+  },
+  {
+    name: '智能燃气表',
+    code: 'GAS-METER',
+    points: [
+      {name: '累计流量', type: 'FLOAT', rw: 'READ_ONLY', unit: 'm³'},
+      {name: '工况流量', type: 'FLOAT', rw: 'READ_ONLY', unit: 'm³/h'},
+      {name: '标况流量', type: 'FLOAT', rw: 'READ_ONLY', unit: 'm³/h'},
+      {name: '压力', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kPa'},
+      {name: '温度', type: 'FLOAT', rw: 'READ_ONLY', unit: '℃'},
+    ],
+  },
+  {
+    name: '光伏逆变器',
+    code: 'PV-INVERTER',
+    points: [
+      {name: '日发电量', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kWh'},
+      {name: '累计发电量', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kWh'},
+      {name: '输出功率', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kW'},
+      {name: '输入电压', type: 'FLOAT', rw: 'READ_ONLY', unit: 'V'},
+      {name: '机内温度', type: 'FLOAT', rw: 'READ_ONLY', unit: '℃'},
+      {name: '运行状态', type: 'BOOLEAN', rw: 'READ_ONLY', unit: ''},
+    ],
+  },
+  {
+    name: 'UPS电源',
+    code: 'UPS-POWER',
+    points: [
+      {name: '输入电压', type: 'FLOAT', rw: 'READ_ONLY', unit: 'V'},
+      {name: '输出电压', type: 'FLOAT', rw: 'READ_ONLY', unit: 'V'},
+      {name: '负载率', type: 'FLOAT', rw: 'READ_ONLY', unit: '%'},
+      {name: '电池容量', type: 'FLOAT', rw: 'READ_ONLY', unit: '%'},
+      {name: '运行状态', type: 'BOOLEAN', rw: 'READ_ONLY', unit: ''},
+      {name: '旁路开关', type: 'BOOLEAN', rw: 'READ_WRITE', unit: ''},
+    ],
+  },
+  {
+    name: '光伏组串',
+    code: 'PV-STRING',
+    points: [
+      {name: '组串电压', type: 'FLOAT', rw: 'READ_ONLY', unit: 'V'},
+      {name: '组串电流', type: 'FLOAT', rw: 'READ_ONLY', unit: 'A'},
+      {name: '组串功率', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kW'},
+    ],
+  },
+  {
+    name: '交流充电桩',
+    code: 'CHARGING-PILE',
+    points: [
+      {name: '充电状态', type: 'BOOLEAN', rw: 'READ_ONLY', unit: ''},
+      {name: '充电功率', type: 'FLOAT', rw: 'READ_WRITE', unit: 'kW'},
+      {name: '累计充电量', type: 'FLOAT', rw: 'READ_ONLY', unit: 'kWh'},
+      {name: '输出电压', type: 'FLOAT', rw: 'READ_ONLY', unit: 'V'},
+      {name: '输出电流', type: 'FLOAT', rw: 'READ_ONLY', unit: 'A'},
+      {name: '启停指令', type: 'BOOLEAN', rw: 'WRITE_ONLY', unit: ''},
+    ],
+  },
+  {
+    name: '螺杆式空压机',
+    code: 'AIR-COMPRESSOR',
+    points: [
+      {name: '排气压力', type: 'FLOAT', rw: 'READ_ONLY', unit: 'MPa'},
+      {name: '排气温度', type: 'FLOAT', rw: 'READ_ONLY', unit: '℃'},
+      {name: '运行状态', type: 'BOOLEAN', rw: 'READ_ONLY', unit: ''},
+      {name: '累计运行时间', type: 'INT', rw: 'READ_ONLY', unit: 'h'},
+      {name: '启停指令', type: 'BOOLEAN', rw: 'WRITE_ONLY', unit: ''},
+    ],
+  },
+  {
+    name: '冷库机组',
+    code: 'COLD-STORAGE',
+    points: [
+      {name: '库内温度', type: 'FLOAT', rw: 'READ_ONLY', unit: '℃'},
+      {name: '设定温度', type: 'FLOAT', rw: 'READ_WRITE', unit: '℃'},
+      {name: '蒸发温度', type: 'FLOAT', rw: 'READ_ONLY', unit: '℃'},
+      {name: '冷凝温度', type: 'FLOAT', rw: 'READ_ONLY', unit: '℃'},
+      {name: '压缩机状态', type: 'BOOLEAN', rw: 'READ_ONLY', unit: ''},
+    ],
+  },
 ];
 
 export const drivers: DriverRecord[] = driverDefs.map((d, i) => ({
@@ -130,7 +228,7 @@ export const profiles: ProfileRecord[] = profileDefs.map((p, i) => ({
   profileCode: p.code,
   profileShareFlag: 'TENANT',
   profileTypeFlag: 'USER',
-  enableFlag: i === 4 ? 'DISABLE' : 'ENABLE',
+  enableFlag: i === 4 || i === 10 ? 'DISABLE' : 'ENABLE',
   createTime: CREATED,
   operateTime: UPDATED,
 }));
@@ -153,11 +251,11 @@ export const points: PointRecord[] = profileDefs.flatMap((def, pi) =>
   })),
 );
 
-// 2–3 devices per profile, each linked to a driver + its profile.
+// 3–6 devices per profile, each linked to a driver + its profile.
 export const devices: DeviceRecord[] = profiles.flatMap((profile, pi) => {
-  const count = 2 + (pi % 2);
+  const count = 3 + (pi % 4);
   return Array.from({length: count}, (_, k) => {
-    const index = pi * 3 + k;
+    const index = pi * 6 + k;
     const driver = drivers[(pi + k) % drivers.length];
     return {
       id: String(3001 + index),


### PR DESCRIPTION
## AI assistant (was hidden in mock)
- Fetch mock intercepts `/api/v3/agentic/chat/completions` (assistant streams over raw fetch, not axios) → scripted keyword-aware replies (temperature/energy/driver/point) with reasoning traces + visualizations (8 chart types)
- Assistant now shown in mock builds; 4 seeded multi-turn sessions (12 messages) with chart-bearing replies

## Dashboard (home cards were sparse)
- Register the 8 insight endpoints → LiveDataFeed/AnalyticsTabs/SlaBadge/LatencyChart/ActivityHeatmap now render real content

## Entity data (was thin)
- Drivers 8→17, profiles 6→14, points 18→59, devices ~15→65

## Verification
vue-tsc green / 158 unit tests / build:mock succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)